### PR TITLE
Feature/doc gettingstarted

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,54 @@ In practice,
 This design ensures that each component, mainly applications but Proxies and Brokers as well, can be addressed in tasks. Should the need arise in the future, this network could be federated by federating the brokers (not unsimilar to E-Mail/SMTP, XMPP, etc.)
 
 ## Getting started
-Running the `broker` binary will open a central broker instance listening on `0.0.0.0:8080` (default, see CLI args for options). The instance can be queried via the API (see next section).
+The following paragraph simulates the creation and the completion of a task
+using [cURL](http://curl.se) calls. Two parties (and their Samply.Proxies) are
+connected via a central broker. Each party runs an application, called `app1`.
+We will simulate this application.
+
+The used BeamIds are the following:
+
+| Sysem          | BeamID                         |
+|----------------|--------------------------------|
+| Broker         | broker.example.de              |
+| Proxy1         | proxy1.broker.example.de       |
+| App1, Party 1  | app1.proxy1.broker.example.de  |
+| Proxy2         | proxy2.broker.example.de       |
+| App1, Party 2  | app1.proxy2.broker.example.de  |
+
+In the example, `app1` uses the ApiKey `App1Key` for both parties.
+
+### Creating a task
+`app1` at party 1 creates a new task at `proxy1.broker.example.de`:
+```
+curl -k -X POST -v -d "" -H "Authorization: ApiKey app1.proxy1.broker.example.de App1Key" -H "Content-Type: application/json" https://proxy1.broker.example.de/v1/tasks
+```
+This results in the reply:
+```
+HTTP/1.1 201 Created
+location: /tasks/b999cf15-3c31-408f-a3e6-a47502308799
+content-length: 0
+date: Mon, 27 Jun 2022 13:58:35 GMT
+```
+where the `location` header field is the id of the newly created task.
+
+### Listening for relevant tasks
+`app1` at Party 2 is now able to fetch all tasks adressed to them, namely the created task:
+```
+curl -k -X GET -v -H "Authorization: ApiKey app1.proxy2.broker.example.de App1Key" https://proxy2.broker.example.de/v1/tasks&to=app1.proxy2.broker.example.de
+```
+
+TODO: Acknowledge and `PUT` status=processing result.
+
+### Returning a Result
+With the task at hand, party 2 processes the task. No doubt, important work is
+done here. After succeeding, `app1` at party 2 wants to return the frout of its
+labour to party 1 and creates a result:
+
+TODO: PUT result
+
+### Waiting for tasks to complete
+TODO Long-Polling
 
 ## Data objects (JSON)
 ### Task

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ In this example, we use the same ApiKey `AppKey` for both parties.
 at party 2 is capable of solving it, so it asks `proxy1.broker.example.de` to
 create that new task:
 ```
-curl -k -X POST -v --json '{"body":"What is the answer to the ultimate question of life, the universe, and everything?","failure_strategy":{"retry":{"backoff_millisecs":1000,"max_tries":5}},"from":"app.proxy1.broker.example.de","id":"70c0aa90-bfcf-4312-a6af-42cbd57dc0b8","metadata":"The broker can read and use this field e.g., to apply filters on behalf of an app","to":["app.proxy2.broker.example.de"]}' -H "Authorization: ApiKey app.proxy1.broker.example.de App1Key" https://proxy1.broker.example.de/v1/tasks
+curl -k -v --json '{"body":"What is the answer to the ultimate question of life, the universe, and everything?","failure_strategy":{"retry":{"backoff_millisecs":1000,"max_tries":5}},"from":"app.proxy1.broker.example.de","id":"70c0aa90-bfcf-4312-a6af-42cbd57dc0b8","metadata":"The broker can read and use this field e.g., to apply filters on behalf of an app","to":["app.proxy2.broker.example.de"]}' -H "Authorization: ApiKey app.proxy1.broker.example.de AppKey" https://proxy1.broker.example.de/v1/tasks
 ```
 `Proxy1` replies:
 ```
 HTTP/1.1 201 Created
-location: /tasks/b999cf15-3c31-408f-a3e6-a47502308799
+location: /tasks/ 70c0aa90-bfcf-4312-a6af-42cbd57dc0b8
 content-length: 0
 date: Mon, 27 Jun 2022 13:58:35 GMT
 ```
@@ -99,21 +99,21 @@ The `filter=todo` parameter instructs the Broker to only send unfinished tasks
 addressed to the querying party.
 The query returns the task, and as `app` at Proxy 2, we inform the broker that
 we are working on this important task by creating a preliminary "result" with
-`"status": "Claimed"`:
+`"status": "claimed"`:
 ```
-curl -k -X POST -v --json "{"from":"app.proxy2.broker.example.de","id":"8db76400-e2d9-4d9d-881f-f073336338c1","metadata":["Arbitrary","types","are","possible"],"status":"claimed","task":"70c0aa90-bfcf-4312-a6af-42cbd57dc0b8","to":["app.proxy1.broker.example.de"]}" -H "Authorization: ApiKey app.proxy2.broker.example.de AppKey" https://proxy2.broker.example.de/v1/tasks/70c0aa90-bfcf-4312-a6af-42cbd57dc0b8/results
+curl -k -X PUT -v --json "{"from":"app.proxy2.broker.example.de","id":"8db76400-e2d9-4d9d-881f-f073336338c1","metadata":["Arbitrary","types","are","possible"],"status":"claimed","task":"70c0aa90-bfcf-4312-a6af-42cbd57dc0b8","to":["app.proxy1.broker.example.de"]}" -H "Authorization: ApiKey app.proxy2.broker.example.de AppKey" https://proxy2.broker.example.de/v1/tasks/70c0aa90-bfcf-4312-a6af-42cbd57dc0b8/results
 ```
 
 ### Returning a Result
 Party 2 processes the received task. After succeeding, `app` at party 2 returns the result to party 1:
 ```
-curl -k -X POST -v --json "{"from":"app.proxy2.broker.example.de","id":"8db76400-e2d9-4d9d-881f-f073336338c1","metadata":["Arbitrary","types","are","possible"],"status":{"succeeded":"The answer is 42"},"task":"70c0aa90-bfcf-4312-a6af-42cbd57dc0b8","to":["app.proxy1.broker.example.de"]}" -H "Authorization: ApiKey app.proxy2.broker.example.de AppKey" https://proxy2.broker.example.de/v1/tasks/70c0aa90-bfcf-4312-a6af-42cbd57dc0b8/results
+curl -k -X PUT -v --json "{"from":"app.proxy2.broker.example.de","id":"8db76400-e2d9-4d9d-881f-f073336338c1","metadata":["Arbitrary","types","are","possible"],"status":{"succeeded":"The answer is 42"},"task":"70c0aa90-bfcf-4312-a6af-42cbd57dc0b8","to":["app.proxy1.broker.example.de"]}" -H "Authorization: ApiKey app.proxy2.broker.example.de AppKey" https://proxy2.broker.example.de/v1/tasks/70c0aa90-bfcf-4312-a6af-42cbd57dc0b8/results
 ```
 
 ### Waiting for tasks to complete
 Meanwhile, `app` at party 1 waits on the completion of its task. But not wanting to check for results every couple seconds, it asks Proxy 1 to be informed if the expected number of `1` result is present:
 ```
-curl -k -X GET -v -H "Authorization: ApiKey app.proxy1.broker.example.de AppKey" https://proxy1.broker.example.de/v1/tasks/70c0aa90-bfcf-4312-a6af-42cbd57dc0b8/results?poll_count=1
+curl -k -X GET -v -H "Authorization: ApiKey app.proxy1.broker.example.de AppKey" https://proxy1.broker.example.de/v1/tasks/70c0aa90-bfcf-4312-a6af-42cbd57dc0b8/results?wait_count=1
 ```
 This *long polling* opens the connection and sleeps until a reply is recieved. For more information, see the API documentation.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ In the example, `app1` uses the ApiKey `App1Key` for both parties.
 ### Creating a task
 `app1` at party 1 creates a new task at `proxy1.broker.example.de`:
 ```
-curl -k -X POST -v -d "" -H "Authorization: ApiKey app1.proxy1.broker.example.de App1Key" -H "Content-Type: application/json" https://proxy1.broker.example.de/v1/tasks
+curl -k -X POST -v -d '{"body":"Much work to do","failure_strategy":{"retry":{"backoff_millisecs":1000,"max_tries":5}},"from":"app1.proxy1.broker.example.de","id":"70c0aa90-bfcf-4312-a6af-42cbd57dc0b8","metadata":"The broker can read and use this field e.g., to apply filters on behalf of an app","to":["app1.proxy2.broker.example.de"]}' -H "Authorization: ApiKey app1.proxy1.broker.example.de App1Key" -H "Content-Type: application/json" https://proxy1.broker.example.de/v1/tasks
 ```
 This results in the reply:
 ```
@@ -90,10 +90,15 @@ where the `location` header field is the id of the newly created task.
 ### Listening for relevant tasks
 `app1` at Party 2 is now able to fetch all tasks adressed to them, namely the created task:
 ```
-curl -k -X GET -v -H "Authorization: ApiKey app1.proxy2.broker.example.de App1Key" https://proxy2.broker.example.de/v1/tasks&to=app1.proxy2.broker.example.de
+curl -k -X GET -v -H "Authorization: ApiKey app1.proxy2.broker.example.de App1Key" https://proxy2.broker.example.de/v1/tasks?filter=todo
 ```
+The `filter=todo` parameter instructs the Broker to only send unfinished tasks
+adressed to the querying party.
+The query returns the task, and we as `app1` at party 2 inform the broker that
+we are working on this important task by creating a bare-bones result with
+`"status": "Claimed"`:
 
-TODO: Acknowledge and `PUT` status=processing result.
+TODO: Create Claimed result
 
 ### Returning a Result
 With the task at hand, party 2 processes the task. No doubt, important work is


### PR DESCRIPTION
This branch documents a full example run in the "Getting Started" section. 
Two API changes are in discussion at the moment:
 1. Using the HTTP `PUT` method to create results (to highlight the idempotency of the call)
 2. Not returning `status: Claimed` results while long polling.

This PR should only be merged after coming to a conclusion and adapting the documentation acordingly.