### PR TITLE
doc: Added Note for Build Dependency libssl-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ date: Mon, 27 Jun 2022 14:26:45 GMT
 
 ## Development Environment
 
+> NOTE: The commands in this section will build the beam proxy and broker locally. To build beam, you need to install libssl-dev.
+
 A dev environment is provided consisting of one broker and two proxies. 
 
 To start the dev setup:


### PR DESCRIPTION
Just a little note on dependency for libssl-dev. The error message confused me then trying to just run `dev/beamdev start`.