### PR TITLE
Support TLS terminating proxy servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,3 +320,4 @@ To work with the environment, you may run `./dev/beamdev defaults` to see some h
 - [ ] Broker-side filtering of the unencrypted fields with JSON queries
 - [ ] Integration of OAuth2 (in discussion)
 - [x] Helpful dev environment
+- [x] Support TLS-terminating proxies

--- a/proxy/src/serve.rs
+++ b/proxy/src/serve.rs
@@ -9,7 +9,7 @@ use crate::{serve_health, serve_tasks};
 pub(crate) async fn serve() -> anyhow::Result<()> {
     let config = config::CONFIG_PROXY.clone();
     
-    let client = shared::http_proxy::build_hyper_client(config.http_proxy)
+    let client = shared::http_proxy::build_hyper_client(config.http_proxy, config.tls_ca_certificates)
         .map_err(SamplyBeamError::HttpProxyProblem)?;
 
     let router_tasks = serve_tasks::router(&client);

--- a/shared/src/config_broker.rs
+++ b/shared/src/config_broker.rs
@@ -18,6 +18,10 @@ struct CliArgs {
     #[clap(long, env, value_parser)]
     http_proxy: Option<String>,
 
+    /// Outgoing HTTP proxy: Directory with CA certificates to trust for TLS connections (e.g. /etc/samply/cacerts/)
+    #[clap(long, env, value_parser)]
+    pub tls_ca_certificates_dir: Option<PathBuf>,
+
     /// The broker's base URL, e.g. https://beam.samply.de
     #[clap(long, env, value_parser)]
     broker_url: Uri,

--- a/shared/src/crypto.rs
+++ b/shared/src/crypto.rs
@@ -32,7 +32,7 @@ impl CertificateCache {
                     certs.push(file.path().to_str().unwrap().into());
                 }
             }
-            debug!("Loaded local certificates: {}", certs);
+            debug!("Loaded local certificates: {}", certs.join(" "));
         }
         Ok(Self{
         serial_to_x509: HashMap::new(),

--- a/shared/src/crypto.rs
+++ b/shared/src/crypto.rs
@@ -32,7 +32,7 @@ impl CertificateCache {
                     certs.push(file.path().to_str().unwrap().into());
                 }
             }
-            println!("{:?}", certs);
+            debug!("Loaded local certificates: {}", certs);
         }
         Ok(Self{
         serial_to_x509: HashMap::new(),

--- a/shared/src/http_proxy.rs
+++ b/shared/src/http_proxy.rs
@@ -3,13 +3,14 @@ use std::time::Duration;
 use http::Uri;
 use hyper::{Client, client::{HttpConnector, connect::Connect}, service::Service};
 use hyper_proxy::{Intercept, Proxy, ProxyConnector, Custom};
-use hyper_tls::HttpsConnector;
+use hyper_tls::{HttpsConnector, native_tls::{TlsConnector, Certificate}};
 use once_cell::sync::OnceCell;
+use openssl::x509::X509;
 use tracing::{debug, info};
 
 use crate::{config, errors::SamplyBeamError, BeamId};
 
-pub fn build_hyper_client(proxy_uri: Option<Uri>) -> Result<Client<ProxyConnector<HttpsConnector<HttpConnector>>>, std::io::Error> {
+pub fn build_hyper_client(proxy_uri: Option<Uri>, ca_certificates: Vec<X509>) -> Result<Client<ProxyConnector<HttpsConnector<HttpConnector>>>, std::io::Error> {
     let proxy = if let Some(proxy_uri) = proxy_uri {
         info!("Using proxy {}", proxy_uri);
         Proxy::new(Intercept::All, proxy_uri)
@@ -19,7 +20,19 @@ pub fn build_hyper_client(proxy_uri: Option<Uri>) -> Result<Client<ProxyConnecto
     let mut http = HttpConnector::new();
     http.enforce_http(false);
     http.set_connect_timeout(Some(Duration::from_secs(1)));
-    let proxy_connector = ProxyConnector::from_proxy(HttpsConnector::new_with_connector(http), proxy)?;
+    let mut proxy_connector = ProxyConnector::from_proxy(HttpsConnector::new_with_connector(http), proxy)?;
+    if ! ca_certificates.is_empty() {
+        let mut tls = TlsConnector::builder();
+        for cert in ca_certificates {
+            const ERR: &str = "Internal Error: Unable to convert Certificate.";
+            let cert = Certificate::from_pem(&cert.to_pem().expect(ERR)).expect(ERR);
+            tls.add_root_certificate(cert);
+        }
+        let tls = tls
+            .build()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("Unable to build TLS Connector with custom CA certificates: {}", e)))?;
+        proxy_connector.set_tls(Some(tls));
+    }
     
     Ok(Client::builder().build(proxy_connector))
 }
@@ -27,36 +40,48 @@ pub fn build_hyper_client(proxy_uri: Option<Uri>) -> Result<Client<ProxyConnecto
 #[cfg(test)]
 mod test {
 
+    use std::path::{Path, PathBuf};
+
     use hyper::{Client, client::{HttpConnector, connect::Connect}, Uri, Request, body};
     use hyper_proxy::ProxyConnector;
     use hyper_tls::HttpsConnector;
+    use openssl::x509::X509;
 
     use super::build_hyper_client;
 
     const HTTP: &str = "http://ip-api.com/json";
     const HTTPS: &str = "https://ifconfig.me/";
 
+    fn get_certs() -> Vec<X509> {
+        if let Ok(dir) = std::env::var("TLS_CA_CERTIFICATES_DIR") {
+            let dir = PathBuf::from(dir);
+            crate::crypto::load_certificates_from_dir(Some(dir)).unwrap()
+        } else {
+            Vec::new()
+        }
+    }
+
     #[tokio::test]
     async fn https_without_proxy() {
-        let client = build_hyper_client(None).unwrap();
+        let client = build_hyper_client(None, get_certs()).unwrap();
         run(HTTPS.parse().unwrap(), client).await;
     }
 
     #[tokio::test]
     async fn http_without_proxy() {
-        let client = build_hyper_client(None).unwrap();
+        let client = build_hyper_client(None, get_certs()).unwrap();
         run(HTTP.parse().unwrap(), client).await;
     }
 
     #[tokio::test]
     async fn http_with_proxy() {
-        let client = build_hyper_client(Some("http://localhost:3128".parse().unwrap())).unwrap();
+        let client = build_hyper_client(Some("http://localhost:3128".parse().unwrap()), get_certs()).unwrap();
         run(HTTP.parse().unwrap(), client).await;
     }
 
     #[tokio::test]
     async fn https_with_proxy() {
-        let client = build_hyper_client(Some("http://localhost:3128".parse().unwrap())).unwrap();
+        let client = build_hyper_client(Some("http://localhost:3128".parse().unwrap()), get_certs()).unwrap();
         run(HTTPS.parse().unwrap(), client).await;
     }
 


### PR DESCRIPTION
This turned out difficult to test. Would be grateful if this could be tested at an actual site (@patrickskowronekdkfz) or with the demo setup (@TKussel).

However, fully backwards compatible and won't hurt if the new env var is not set.

A helpful command line for testing:
```
docker run --rm -ti -v $(pwd)/certs:/home/mitmproxy/.mitmproxy -p 3128:3128 mitmproxy/mitmproxy mitmproxy --listen-port 3128
```