### PR TITLE
Support NO_PROXY environment variable

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,8 +32,8 @@
                 "PROXY_ID": "proxy2.broker",
                 "PRIVKEY_FILE": "dev/pki/proxy2.priv.pem",
                 "BIND_ADDR": "0.0.0.0:8082",
-                "http_proxy": "",
-                "HTTP_PROXY": "",
+                "all_proxy": "",
+                "ALL_PROXY": "",
             }
         },
         {

--- a/proxy/src/serve.rs
+++ b/proxy/src/serve.rs
@@ -9,7 +9,7 @@ use crate::{serve_health, serve_tasks};
 pub(crate) async fn serve() -> anyhow::Result<()> {
     let config = config::CONFIG_PROXY.clone();
     
-    let client = shared::http_proxy::build_hyper_client(config.http_proxy, config.tls_ca_certificates)
+    let client = shared::http_proxy::build_hyper_client(config.tls_ca_certificates)
         .map_err(SamplyBeamError::HttpProxyProblem)?;
 
     let router_tasks = serve_tasks::router(&client);

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -24,6 +24,7 @@ hyper = { version = "0.14.19", features = ["full"] }
 # HTTP client with proxy support
 hyper-tls = "0.5.0"
 hyper-proxy = "0.9.1"
+mz-http-proxy = { version = "0.1.0", features = ["hyper"] }
 
 # Logging
 tracing = "0.1.35"
@@ -49,7 +50,7 @@ anyhow = "1.0.58"
 # Command Line Interface
 clap = { version = "3.2.8", features = ["env", "derive"] }
 
-http = "*"
+http = "0.2.8"
 
 [dev-dependencies]
 tokio-test = "0.4.2"

--- a/shared/src/config.rs
+++ b/shared/src/config.rs
@@ -34,7 +34,7 @@ pub(crate) static CONFIG_SHARED: config_shared::Config = {
 };
 
 pub fn prepare_env() {
-    for var in ["http_proxy"] {
+    for var in ["http_proxy", "https_proxy", "all_proxy", "no_proxy"] {
         for (k,v) in std::env::vars().filter(|(k,_)| k.to_lowercase() == var) {
             std::env::set_var(k.to_uppercase(), v);
         }

--- a/shared/src/config_broker.rs
+++ b/shared/src/config_broker.rs
@@ -8,15 +8,11 @@ use tracing::info;
 use std::str::FromStr;
 
 #[derive(Parser,Debug)]
-#[clap(name("Samply.Beam.Broker"), version, arg_required_else_help(true))]
+#[clap(name("🌈 Samply.Beam.Broker"), version, arg_required_else_help(true), after_help(crate::config_shared::CLAP_FOOTER))]
 struct CliArgs {
     /// Local bind address
     #[clap(long, env, value_parser, default_value_t = SocketAddr::from_str("0.0.0.0:8080").unwrap())]
     bind_addr: SocketAddr,
-
-    /// Outgoing HTTP proxy (e.g. http://myproxy.mynetwork:3128)
-    #[clap(long, env, value_parser)]
-    http_proxy: Option<String>,
 
     /// Outgoing HTTP proxy: Directory with CA certificates to trust for TLS connections (e.g. /etc/samply/cacerts/)
     #[clap(long, env, value_parser)]

--- a/shared/src/crypto.rs
+++ b/shared/src/crypto.rs
@@ -406,6 +406,5 @@ pub fn load_certificates_from_dir(ca_dir: Option<PathBuf>) -> Result<Vec<X509>, 
             result.push(cert);
         }
     }
-    info!("Loaded {} trusted CA certificates for outgoing TLS connections.", result.len());
     Ok(result)
 }

--- a/shared/src/http_proxy.rs
+++ b/shared/src/http_proxy.rs
@@ -1,29 +1,27 @@
-use std::time::Duration;
+use std::{time::Duration, collections::HashSet};
 
 use http::Uri;
-use hyper::{Client, client::{HttpConnector, connect::Connect}, service::Service};
+use hyper::{Client, client::{HttpConnector, connect::Connect, conn}, service::Service};
 use hyper_proxy::{Intercept, Proxy, ProxyConnector, Custom};
 use hyper_tls::{HttpsConnector, native_tls::{TlsConnector, Certificate}};
+use mz_http_proxy::hyper::connector;
 use once_cell::sync::OnceCell;
 use openssl::x509::X509;
 use tracing::{debug, info};
 
 use crate::{config, errors::SamplyBeamError, BeamId};
 
-pub fn build_hyper_client(proxy_uri: Option<Uri>, ca_certificates: Vec<X509>) -> Result<Client<ProxyConnector<HttpsConnector<HttpConnector>>>, std::io::Error> {
-    let proxy = if let Some(proxy_uri) = proxy_uri {
-        info!("Using proxy {}", proxy_uri);
-        Proxy::new(Intercept::All, proxy_uri)
-    } else {
-        Proxy::new(Intercept::None, "http://bogusproxy:4223".parse().unwrap())
-    };
+pub fn build_hyper_client(ca_certificates: Vec<X509>) -> Result<Client<ProxyConnector<HttpsConnector<HttpConnector>>>, std::io::Error> {
     let mut http = HttpConnector::new();
-    http.enforce_http(false);
     http.set_connect_timeout(Some(Duration::from_secs(1)));
-    let mut proxy_connector = ProxyConnector::from_proxy(HttpsConnector::new_with_connector(http), proxy)?;
+    http.enforce_http(false);
+    let https = HttpsConnector::new_with_connector(http);
+    let proxy_connector = connector()
+        .map_err(|e| panic!("Unable to build HTTP client: {}", e)).unwrap();
+    let mut proxy_connector = proxy_connector.with_connector(https);
     if ! ca_certificates.is_empty() {
         let mut tls = TlsConnector::builder();
-        for cert in ca_certificates {
+        for cert in &ca_certificates {
             const ERR: &str = "Internal Error: Unable to convert Certificate.";
             let cert = Certificate::from_pem(&cert.to_pem().expect(ERR)).expect(ERR);
             tls.add_root_certificate(cert);
@@ -33,6 +31,26 @@ pub fn build_hyper_client(proxy_uri: Option<Uri>, ca_certificates: Vec<X509>) ->
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("Unable to build TLS Connector with custom CA certificates: {}", e)))?;
         proxy_connector.set_tls(Some(tls));
     }
+
+    let proxies = proxy_connector.proxies().iter()
+        .map(|p| p.uri().to_string())
+        .collect::<HashSet<_>>();
+
+    if proxies.len() == 0 && ca_certificates.len() > 0 {
+        return Err(std::io::Error::new(std::io::ErrorKind::Other, "Certificates for TLS termination were provided but no proxy to use. Please supply correct configuration."));
+    }
+
+    let proxies = match proxies.len() {
+        0 => "no proxy".to_string(),
+        1 => format!("proxy {}", proxies.iter().next().unwrap()),
+        num => format!("{num} proxies {:?}", proxies)
+    };
+    let certs = match ca_certificates.len() {
+        0 => "but no trusted certificate".to_string(),
+        1 => "with one trusted certificate".to_string(),
+        num => format!("with {num} trusted certificates")
+    };
+    info!("Using {proxies} {certs} for TLS termination.");
     
     Ok(Client::builder().build(proxy_connector))
 }
@@ -62,27 +80,15 @@ mod test {
     }
 
     #[tokio::test]
-    async fn https_without_proxy() {
-        let client = build_hyper_client(None, get_certs()).unwrap();
+    async fn https() {
+        let client = build_hyper_client(get_certs()).unwrap();
         run(HTTPS.parse().unwrap(), client).await;
     }
 
     #[tokio::test]
-    async fn http_without_proxy() {
-        let client = build_hyper_client(None, get_certs()).unwrap();
+    async fn http() {
+        let client = build_hyper_client(get_certs()).unwrap();
         run(HTTP.parse().unwrap(), client).await;
-    }
-
-    #[tokio::test]
-    async fn http_with_proxy() {
-        let client = build_hyper_client(Some("http://localhost:3128".parse().unwrap()), get_certs()).unwrap();
-        run(HTTP.parse().unwrap(), client).await;
-    }
-
-    #[tokio::test]
-    async fn https_with_proxy() {
-        let client = build_hyper_client(Some("http://localhost:3128".parse().unwrap()), get_certs()).unwrap();
-        run(HTTPS.parse().unwrap(), client).await;
     }
 
     async fn run(url: Uri, client: Client<impl Connect + Clone + Send + Sync + 'static>) {


### PR DESCRIPTION
@TKussel, could you please repeat the proxy check you did for #48?

We now recommend using the ALL_PROXY, as described in the new startup message.

Unfortunately, the tests would arbitrarily fail/succeed due to the fact that the new proxy library initializes the proxy via env variables and there are some weird race conditions in Rust's testing framework. So the tests now rely on the user setting appropriate proxy vars, e.g. `ALL_PROXY=... cargo test`