### PR TITLE
Fetch certificates via broker

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -90,7 +90,17 @@
                 }
             },
             "args": [],
-            "cwd": "${workspaceFolder}"
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "BROKER_URL": "http://broker:8080",
+                "PKI_ADDRESS": "http://vault:8200",
+                "no_proxy": "vault",
+                "NO_PROXY": "vault",
+                "PRIVKEY_FILE": "dev/pki/dummy.priv.pem",
+                "BIND_ADDR": "0.0.0.0:8080",
+                "RUST_LOG": "DEBUG",
+                "PKI_APIKEY_FILE": "dev/pki/pki.secret",
+            }
         },
         {
             "type": "lldb",
@@ -109,7 +119,7 @@
                 }
             },
             "args": [],
-            "cwd": "${workspaceFolder}"
+            "cwd": "${workspaceFolder}",
         },
         {
             "type": "lldb",

--- a/README.md
+++ b/README.md
@@ -55,9 +55,7 @@ In practice,
 
 This design ensures that each component, mainly applications but Proxies and Brokers as well, can be addressed in tasks. Should the need arise in the future, this network could be federated by federating the brokers (not unsimilar to E-Mail/SMTP, XMPP, etc.)
 
-The Proxies have to fetch certificates from the central Certificate Authority,
-however, this communication is relayed by the broker. This ensures, that no
-external access to the CA is required.
+The Proxies have to fetch certificates from the central Certificate Authority, however, this communication is relayed by the broker. This ensures, that no external access to the CA is required.
 
 ## Getting started
 The following paragraph simulates the creation and the completion of a task

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ In practice,
 
 This design ensures that each component, mainly applications but Proxies and Brokers as well, can be addressed in tasks. Should the need arise in the future, this network could be federated by federating the brokers (not unsimilar to E-Mail/SMTP, XMPP, etc.)
 
+The Proxies have to fetch certificates from the central Certificate Authority,
+however, this communication is relayed by the broker. This ensures, that no
+external access to the CA is required.
+
 ## Getting started
 The following paragraph simulates the creation and the completion of a task
 using [cURL](http://curl.se) calls. Two parties (and their Samply.Proxies) are

--- a/broker/Cargo.toml
+++ b/broker/Cargo.toml
@@ -32,5 +32,7 @@ tracing = "0.1.35"
 hyper = { version = "0.14.19", features = ["full"] }
 hyper-tls = "0.5.0"
 
+vaultrs = { git = "https://github.com/jmgilman/vaultrs", default-features = false, features = [ "native-tls" ] }# <= Change once update > 0.6.2 is out
+
 [build-dependencies]
 build-data = "0"

--- a/broker/src/crypto.rs
+++ b/broker/src/crypto.rs
@@ -1,0 +1,51 @@
+use axum::async_trait;
+use shared::{crypto::GetCerts, errors::SamplyBeamError, config};
+use tracing::debug;
+use vaultrs::{client::{VaultClientSettingsBuilderError, VaultClient, VaultClientSettingsBuilder}, error::ClientError, pki};
+
+pub struct GetCertsFromPki {
+    vault_client: VaultClient,
+    pki_realm: String,
+}
+
+#[async_trait]
+impl GetCerts for GetCertsFromPki {
+    async fn certificate_list(&self) -> Result<Vec<String>,SamplyBeamError> {
+        pki::cert::list(&self.vault_client, &self.pki_realm).await
+            .map_err(|e| SamplyBeamError::VaultError(format!("Error in connection to certificate authority: {e}")))
+    }
+
+    async fn certificate_by_serial_as_pem(&self, serial: &str) -> Result<String,SamplyBeamError> {
+        let certificate = pki::cert::read(&self.vault_client, &self.pki_realm, serial).await
+            .map_err(|e| SamplyBeamError::VaultError(e.to_string()))?;
+        Ok(certificate.certificate)
+    }
+
+    fn new() -> Result<Self,SamplyBeamError> {
+        let mut certs = Vec::new();
+        if let Some(dir) = &config::CONFIG_CENTRAL.tls_ca_certificates_dir {
+            for file in std::fs::read_dir(dir).map_err(|e| SamplyBeamError::ConfigurationFailed(format!("Unable to read CA certificates: {}", e)))? {
+                if let Ok(file) = file {
+                    certs.push(file.path().to_str().unwrap().into());
+                }
+            }
+            debug!("Loaded local certificates: {}", certs.join(" "));
+        }
+        let vault_client = VaultClient::new(
+            VaultClientSettingsBuilder::default()
+                .address(&config::CONFIG_CENTRAL.pki_address.to_string())
+                .token(&config::CONFIG_CENTRAL.pki_token)
+                .ca_certs(certs)
+                .build()
+                .map_err(|e| SamplyBeamError::VaultError(format!("Unable to build vault client settings: {}", e)))?
+            ).map_err(|e| SamplyBeamError::VaultError(format!("Error in connection to certificate authority: {}", e)))?;
+        
+        let pki_realm = config::CONFIG_CENTRAL.pki_realm.clone();
+
+        Ok(Self { vault_client, pki_realm })
+    }
+}
+
+pub(crate) fn build_cert_getter() -> Result<GetCertsFromPki,SamplyBeamError> {
+    GetCertsFromPki::new()
+}

--- a/broker/src/main.rs
+++ b/broker/src/main.rs
@@ -3,7 +3,9 @@
 mod serve;
 mod serve_tasks;
 mod serve_health;
+mod serve_pki;
 mod banner;
+mod crypto;
 
 use std::{collections::HashMap, sync::Arc};
 
@@ -14,6 +16,9 @@ use tracing::info;
 #[tokio::main]
 pub async fn main() -> anyhow::Result<()> {    
     shared::config::prepare_env();
+
+    let cert_getter = crypto::build_cert_getter()?;
+    shared::crypto::init_cert_getter(cert_getter);
 
     #[cfg(debug_assertions)]
     if shared::examples::print_example_objects() { return Ok(()); }

--- a/broker/src/serve.rs
+++ b/broker/src/serve.rs
@@ -10,12 +10,13 @@ use shared::{MsgTaskRequest, MsgTaskResult, MsgId, HowLongToBlock, HasWaitId, Ms
 use tokio::{sync::{broadcast::{Sender, Receiver}, RwLock}, time};
 use tracing::{debug, info, trace};
 
-use crate::{serve_tasks, serve_health};
+use crate::{serve_tasks, serve_health, serve_pki, crypto::GetCertsFromPki};
 
 pub(crate) async fn serve() -> anyhow::Result<()> {
     let app = 
         serve_tasks::router()
         // .merge(serve_pki::router())
+        .merge(serve_pki::router())
         .merge(serve_health::router());
 
     // Graceful shutdown handling

--- a/broker/src/serve_pki.rs
+++ b/broker/src/serve_pki.rs
@@ -1,55 +1,60 @@
 // GET /v1/pki/*path
 
-use std::convert::Infallible;
+use std::{convert::Infallible, string::FromUtf8Error};
 
-use axum::{Extension, http::Request, routing::{Route, get}, Router, response::{Response, IntoResponse}, Json};
+use axum::{Extension, http::Request, routing::{Route, get}, Router, response::{Response, IntoResponse}, Json, extract::{Query, Path}};
 use hyper::{Client, Body, client::HttpConnector, StatusCode};
 use hyper_tls::HttpsConnector;
-use serde::Serialize;
-use shared::config::CONFIG_CENTRAL;
+use serde::{Serialize, Deserialize};
+use shared::{config::CONFIG_CENTRAL, errors::SamplyBeamError};
 use thiserror::Error;
+use tracing::{error, info, debug};
+use vaultrs::pki;
 
 #[derive(Error, Debug)]
 enum PkiError {
-    #[error("Some unused error")]
-    Error1,
-    #[error("Another unused error")]
-    Error2,
+    #[error("Error in communication with PKI. {0}")]
+    CommunicationWithVault(String),
+    #[error("Error processing certificate: {0}")]
+    OpenSslError(String),
+    #[error("Unable to parse response: {0}")]
+    ParseError(#[from] FromUtf8Error)
 }
 
 impl IntoResponse for PkiError {
     fn into_response(self) -> Response {
-        match self {
-            PkiError::Error1 
-          | PkiError::Error2 => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                self.to_string()
-        )}.into_response()
+        let status = match self {
+            PkiError::CommunicationWithVault(_)
+                => StatusCode::BAD_GATEWAY,
+            PkiError::OpenSslError(_) | PkiError::ParseError(_)
+                => StatusCode::PRECONDITION_FAILED,
+        };
+        
+        (status, self.to_string()).into_response()
     }
 }
 
-#[derive(Serialize,Clone)]
-struct PkiInfo {
-    url: String,
-    realm: String,
-}
-
 pub(crate) fn router() -> Router {
-    let pki_info = PkiInfo {
-        url: CONFIG_CENTRAL.pki_address.to_string(),
-        realm: CONFIG_CENTRAL.pki_realm.clone(),
-    };
-
     Router::new()
-        .route("/v1/pki/info", get(info))
-        .layer(Extension(pki_info))
+        .route("/v1/pki/certs", get(get_certificate_list))
+        .route("/v1/pki/certs/by_serial/:serial", get(get_certificate_by_serial))
 }
 
-async fn info(
-    // Extension(client): Extension<Client<ProxyConnector<HttpsConnector<HttpConnector>>>>,
-    // Extension(config): Extension<config_proxy::Config>,
-    // req: Request<Body>,
-    Extension(pki_info): Extension<PkiInfo>
-) -> Result<Json<PkiInfo>, PkiError> {
-    Ok(Json(pki_info))
+async fn get_certificate_by_serial(
+    Path(serial): Path<String>
+) -> Result<String, PkiError> {
+    debug!("=> Asked for Serial {serial}");
+    let cert = shared::crypto::get_cert_and_client_by_serial_as_pemstr(&serial).await
+        .ok_or(PkiError::CommunicationWithVault(String::new()))?;
+    let pem = cert.cert.to_pem()
+        .map_err(|e| PkiError::OpenSslError(e.to_string()))?;
+    Ok(String::from_utf8(pem)?)
 }
+
+async fn get_certificate_list() -> Result<Json<Vec<String>>,PkiError> {
+    debug!("Asked for all certificates.");
+    let list = shared::crypto::get_serial_list().await
+        .map_err(|e| PkiError::CommunicationWithVault(e.to_string()))?;
+    let json = Json(list);
+    Ok(json)
+} 

--- a/proxy/src/crypto.rs
+++ b/proxy/src/crypto.rs
@@ -1,0 +1,83 @@
+use axum::{async_trait, Json};
+use hyper::{Client, client::HttpConnector, Uri, StatusCode};
+use hyper_proxy::ProxyConnector;
+use hyper_tls::HttpsConnector;
+use shared::{crypto::GetCerts, errors::SamplyBeamError, config, config_proxy::Config};
+use tracing::debug;
+
+pub(crate) struct GetCertsFromBroker {
+    client: Client<ProxyConnector<HttpsConnector<HttpConnector>>>,
+    broker_url: Uri
+}
+
+impl GetCertsFromBroker {
+    async fn query(&self, path: String) -> Result<String,SamplyBeamError> {
+        let uri = Uri::builder()
+            .scheme(self.broker_url.scheme().unwrap().to_owned())
+            .authority(self.broker_url.authority().unwrap().to_owned())
+            .path_and_query(path)
+            .build()?;
+        let mut req = self.client.get(uri).await?;
+        let resp = hyper::body::to_bytes(req.body_mut()).await?;
+        let resp = String::from_utf8(resp.to_vec())
+            .map_err(|e| SamplyBeamError::HttpParseError(e))?;
+        if ! req.status().is_success() {
+            match req.status() {
+                StatusCode::NOT_FOUND => Ok(String::new()),
+                x => Err(SamplyBeamError::VaultError(format!("Got code {x}, error message: {}", resp)))
+            }
+        } else {
+            Ok(resp)
+        }
+    }
+
+    async fn query_vec(&self, path: String) -> Result<Vec<String>,SamplyBeamError> {
+        let uri = Uri::builder()
+            .scheme(self.broker_url.scheme().unwrap().to_owned())
+            .authority(self.broker_url.authority().unwrap().to_owned())
+            .path_and_query(path)
+            .build()?;
+        let mut req = self.client.get(uri).await?;
+        let resp = hyper::body::to_bytes(req.body_mut()).await?;
+        let json: Vec<String> = serde_json::from_slice(&resp)
+            .map_err(|e| SamplyBeamError::VaultError(format!("Unable to parse vault reply: {}", e)))?;
+        if ! req.status().is_success() {
+            match req.status() {
+                StatusCode::NOT_FOUND => Ok(json),
+                x => Err(SamplyBeamError::VaultError(format!("Got code {x}")))
+            }
+        } else {
+            Ok(json)
+        }
+    }
+}
+
+#[async_trait]
+impl GetCerts for GetCertsFromBroker {
+    async fn certificate_list(&self) -> Result<Vec<String>,SamplyBeamError> {
+        self.query_vec("/v1/pki/certs".to_string()).await
+    }
+
+    async fn certificate_by_serial_as_pem(&self, serial: &str) -> Result<String,SamplyBeamError> {
+        debug!("Retrieving certificate with serial {serial} ...");
+        self.query(format!("/v1/pki/certs/by_serial/{}", serial)).await
+    }
+
+    fn new() -> Result<Self,SamplyBeamError> {
+        unimplemented!()
+    }
+}
+
+pub(crate) fn build_cert_getter(
+    config: Config, 
+    client: Client<ProxyConnector<HttpsConnector<HttpConnector>>>
+) -> Result<GetCertsFromBroker,SamplyBeamError> {
+    let client = client;
+    let broker_url = config.broker_uri;
+    let _ = broker_url.scheme().ok_or(SamplyBeamError::ConfigurationFailed("Broker URL invalid.".into()))?;
+    let _ = broker_url.authority().ok_or(SamplyBeamError::ConfigurationFailed("Broker URL invalid.".into()))?;
+    // let broker_builder = Uri::builder()
+    //     .scheme(scheme)
+    //     .authority(authority);
+    Ok(GetCertsFromBroker { client, broker_url })
+}

--- a/proxy/src/serve.rs
+++ b/proxy/src/serve.rs
@@ -1,14 +1,12 @@
 use std::fmt::Write;
 
 use hyper::Client;
-use shared::{config, errors::SamplyBeamError};
+use shared::{config, errors::SamplyBeamError, config_shared, config_proxy};
 use tracing::{info, debug, warn, error};
 
 use crate::{serve_health, serve_tasks};
 
-pub(crate) async fn serve() -> anyhow::Result<()> {
-    let config = config::CONFIG_PROXY.clone();
-    
+pub(crate) async fn serve(config: config_proxy::Config) -> anyhow::Result<()> {
     let client = shared::http_proxy::build_hyper_client(config.tls_ca_certificates)
         .map_err(SamplyBeamError::HttpProxyProblem)?;
 

--- a/proxy/src/serve.rs
+++ b/proxy/src/serve.rs
@@ -1,15 +1,14 @@
 use std::fmt::Write;
 
-use hyper::Client;
+use hyper::{Client, client::HttpConnector};
+use hyper_proxy::ProxyConnector;
+use hyper_tls::HttpsConnector;
 use shared::{config, errors::SamplyBeamError, config_shared, config_proxy};
 use tracing::{info, debug, warn, error};
 
 use crate::{serve_health, serve_tasks};
 
-pub(crate) async fn serve(config: config_proxy::Config) -> anyhow::Result<()> {
-    let client = shared::http_proxy::build_hyper_client(config.tls_ca_certificates)
-        .map_err(SamplyBeamError::HttpProxyProblem)?;
-
+pub(crate) async fn serve(config: config_proxy::Config, client: Client<ProxyConnector<HttpsConnector<HttpConnector>>>) -> anyhow::Result<()> {
     let router_tasks = serve_tasks::router(&client);
 
     let router_health = serve_health::router();

--- a/proxy/src/serve_tasks.rs
+++ b/proxy/src/serve_tasks.rs
@@ -1,4 +1,4 @@
-use std::time::SystemTime;
+use std::time::{SystemTime, Duration};
 
 use axum::{Router, Extension, routing::any, response::Response, http::HeaderValue};
 use httpdate::fmt_http_date;

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -36,7 +36,6 @@ rsa = "0.6"
 sha2 = "0.10.2"
 openssl = "0.10.40"
 aes-gcm = "0.9.4"
-vaultrs = { git = "https://github.com/jmgilman/vaultrs", default-features = false, features = [ "native-tls" ] }# <= Change once update > 0.6.2 is out
 jwt-simple = { git = "https://github.com/jedisct1/rust-jwt-simple", rev="b6a2c5be" } # <= Change once version >0.11.0 is out
 
 # Global variables

--- a/shared/src/config.rs
+++ b/shared/src/config.rs
@@ -1,7 +1,8 @@
+use once_cell::sync::OnceCell;
 use static_init::dynamic;
 use tracing::debug;
 
-use crate::{config_proxy, config_broker, config_shared, errors::SamplyBeamError};
+use crate::{config_proxy, config_broker, config_shared::{self, ConfigCrypto}, errors::SamplyBeamError, crypto};
 
 pub(crate) trait Config: Sized{
     fn load() -> Result<Self,SamplyBeamError>;
@@ -32,6 +33,8 @@ pub(crate) static CONFIG_SHARED: config_shared::Config = {
     debug!("Loading config CONFIG_SHARED");
     load()
 };
+
+pub(crate) static CONFIG_SHARED_CRYPTO: OnceCell<ConfigCrypto> = OnceCell::new();
 
 pub fn prepare_env() {
     for var in ["http_proxy", "https_proxy", "all_proxy", "no_proxy"] {

--- a/shared/src/config_broker.rs
+++ b/shared/src/config_broker.rs
@@ -48,6 +48,7 @@ pub struct Config {
     pub pki_address: Uri,
     pub pki_realm: String,
     pub pki_token: String,
+    pub tls_ca_certificates_dir: Option<PathBuf>,
 }
 
 impl crate::config::Config for Config {
@@ -63,6 +64,7 @@ impl crate::config::Config for Config {
             pki_address: cli_args.pki_address,
             pki_realm: cli_args.pki_realm,
             pki_token,
+            tls_ca_certificates_dir: cli_args.tls_ca_certificates_dir
         };
         Ok(config)
     }

--- a/shared/src/config_proxy.rs
+++ b/shared/src/config_proxy.rs
@@ -15,8 +15,6 @@ pub struct Config {
     pub broker_uri: Uri,
     pub broker_host_header: HeaderValue,
     pub bind_addr: SocketAddr,
-    pub pki_address: Uri,
-    pub pki_realm: String,
     pub proxy_id: ProxyId,
     pub api_keys: HashMap<AppId,ApiKey>,
     pub tls_ca_certificates: Vec<X509>
@@ -42,14 +40,6 @@ pub struct CliArgs {
     /// This proxy's beam id, e.g. proxy42.broker23.beam.samply.de
     #[clap(long, env, value_parser)]
     pub proxy_id: String,
-
-    /// samply.pki: URL to HTTPS endpoint
-    #[clap(long, env, value_parser)]
-    pub pki_address: Uri,
-
-    /// samply.pki: Authentication realm
-    #[clap(long, env, value_parser, default_value = "samply_pki")]
-    pub pki_realm: String,
 
     /// samply.pki: File containing the authentication token
     #[clap(long, env, value_parser, default_value = "/run/secrets/pki.secret")]
@@ -103,9 +93,7 @@ impl crate::config::Config for Config {
         let config = Config {
             broker_host_header: uri_to_host_header(&cli_args.broker_url)?,
             broker_uri: cli_args.broker_url,
-            pki_address: cli_args.pki_address,
             bind_addr: cli_args.bind_addr,
-            pki_realm: cli_args.pki_realm,
             proxy_id,
             api_keys,
             tls_ca_certificates

--- a/shared/src/config_shared.rs
+++ b/shared/src/config_shared.rs
@@ -1,10 +1,11 @@
-use crate::{SamplyBeamError, crypto::{self, load_certificates_from_dir}, beam_id::{BrokerId, BeamId}};
+use crate::{SamplyBeamError, crypto::{self, load_certificates_from_dir, get_cert_and_client_by_cname_as_pemstr, CryptoPublicPortion}, beam_id::{BrokerId, BeamId, ProxyId}, config::CONFIG_SHARED_CRYPTO};
 use std::{path::PathBuf, rc::Rc, sync::Arc, fs::read_to_string};
+use axum::async_trait;
 use hyper::Uri;
 use clap::Parser;
 use hyper_tls::native_tls::Certificate;
 use jwt_simple::prelude::RS256KeyPair;
-use openssl::x509::X509;
+use openssl::{x509::{X509, self}, asn1::Asn1IntegerRef};
 use rsa::{RsaPrivateKey, pkcs8::DecodePrivateKey, pkcs1::DecodeRsaPrivateKey};
 use static_init::dynamic;
 use tracing::info;
@@ -57,19 +58,21 @@ pub(crate) struct Config {
     pub(crate) pki_address: Uri,
     pub(crate) pki_realm: String,
     pub(crate) pki_apikey: String,
-    pub(crate) privkey_rs256: RS256KeyPair,
-    pub(crate) privkey_rsa: RsaPrivateKey,
     pub(crate) tls_ca_certificates_dir: Option<PathBuf>,
     // pub(crate) broker_url: Uri,
     pub(crate) broker_domain: String,
+}
+
+pub(crate) struct ConfigCrypto {
+    pub(crate) privkey_rs256: RS256KeyPair,
+    pub(crate) privkey_rsa: RsaPrivateKey,
+    pub(crate) public: CryptoPublicPortion
 }
 
 impl crate::config::Config for Config {
     fn load() -> Result<Self,SamplyBeamError> {
         let cli_args = CliArgs::parse();
         BrokerId::set_broker_id(&cli_args.broker_url.host().unwrap().to_string());
-
-        let (privkey_rsa, privkey_rs256) = load_crypto(&cli_args)?;
     
         // API Key
         let pki_apikey = read_to_string(cli_args.pki_apikey_file)
@@ -82,11 +85,22 @@ impl crate::config::Config for Config {
         }
         let broker_domain = broker_domain.unwrap().to_string();
         let tls_ca_certificates_dir = cli_args.tls_ca_certificates_dir;
-        Ok(Config { pki_address: cli_args.pki_address, pki_realm: cli_args.pki_realm, pki_apikey, privkey_rs256, privkey_rsa, broker_domain, tls_ca_certificates_dir })
+        Ok(Config { pki_address: cli_args.pki_address, pki_realm: cli_args.pki_realm, pki_apikey, broker_domain, tls_ca_certificates_dir })
     }    
 }
 
-fn load_crypto(cli_args: &CliArgs) -> Result<(RsaPrivateKey, RS256KeyPair), SamplyBeamError> {
+pub async fn init_crypto() -> Result<(String, String), SamplyBeamError>{
+    let cli_args = CliArgs::parse();
+    let crypto = load_crypto(&cli_args).await?;
+    let serial = crypto.public.cert.serial_number().to_bn().unwrap().to_hex_str().unwrap().to_string();
+    let cname = crypto.public.cert.subject_name().entries().next().unwrap().data().as_utf8()?.to_string();
+    if CONFIG_SHARED_CRYPTO.set(crypto).is_err() {
+        panic!("Tried to initialize crypto twice (init_crypto())");
+    }
+    Ok((serial, cname))
+}
+
+async fn load_crypto(cli_args: &CliArgs) -> Result<ConfigCrypto, SamplyBeamError> {
     let privkey_pem = read_to_string(&cli_args.privkey_file)
         .map_err(|e| SamplyBeamError::ConfigurationFailed(format!("Unable to load private key from file {}: {}", cli_args.privkey_file.to_string_lossy(), e)))?
         .trim().to_string();
@@ -95,8 +109,54 @@ fn load_crypto(cli_args: &CliArgs) -> Result<(RsaPrivateKey, RS256KeyPair), Samp
         .map_err(|e| SamplyBeamError::ConfigurationFailed(format!("Unable to interpret private key PEM as PKCS#1 or PKCS#8: {}", e)))?;
     let mut privkey_rs256 = RS256KeyPair::from_pem(&privkey_pem)
         .map_err(|e| SamplyBeamError::ConfigurationFailed(format!("Unable to interpret private key PEM as PKCS#1 or PKCS#8: {}", e)))?;
-    if let Some(proxy_id) = &cli_args.proxy_id {
-        privkey_rs256 = privkey_rs256.with_key_id(proxy_id);
+    let proxy_id = cli_args.proxy_id.as_ref()
+        .expect("load_crypto() has been called without setting a Proxy ID (maybe in broker?). This should not happen.");
+    let proxy_id = ProxyId::new(proxy_id)?;
+    let public = get_cert_and_client_by_cname_as_pemstr(&proxy_id).await;
+    if public.is_none() {
+        return Err(SamplyBeamError::SignEncryptError("Unable to parse your certificate.".into()));
     }
-    Ok((privkey_rsa, privkey_rs256))
+    let public = public.unwrap();
+    let serial = asn_str_to_vault_str(public.cert.serial_number())?;
+    privkey_rs256 = privkey_rs256.with_key_id(&serial);
+    let config = ConfigCrypto {
+        privkey_rs256,
+        privkey_rsa,
+        public,
+    };
+    Ok(config)
+}
+
+fn asn_str_to_vault_str(asn: &Asn1IntegerRef) -> Result<String,SamplyBeamError> {
+    let mut a = asn
+        .to_bn()
+        .map_err(|e| SamplyBeamError::SignEncryptError(format!("Unable to parse your certificate: {}", e)))?
+        .to_hex_str()
+        .map_err(|e| SamplyBeamError::SignEncryptError(format!("Unable to parse your certificate: {}", e)))?
+        .to_string()
+        .to_ascii_lowercase();
+
+    let mut i=2;
+    while i<a.len() {
+        a.insert(i, ':');
+        i+=3;
+    }
+    
+    Ok(a)
+}
+
+#[cfg(test)]
+mod test {
+    use openssl::{asn1::{Asn1Integer, Asn1StringRef, Asn1String}, bn::BigNum};
+
+    use super::asn_str_to_vault_str;
+
+
+    #[test]
+    fn hex_str() {
+        let bn = BigNum::from_hex_str("440E0D94F36966391117BC9F867D84F0C48CFCB7").unwrap();
+        let input = Asn1Integer::from_bn(&bn).unwrap();
+        let expected = "44:0e:0d:94:f3:69:66:39:11:17:bc:9f:86:7d:84:f0:c4:8c:fc:b7";
+        assert_eq!(expected, asn_str_to_vault_str(&input).unwrap());
+    }
 }

--- a/shared/src/crypto.rs
+++ b/shared/src/crypto.rs
@@ -1,6 +1,7 @@
 use aes_gcm::aead::generic_array::GenericArray;
-use axum::{Json, http::Request, body::Body};
+use axum::{Json, http::Request, body::Body, async_trait};
 
+use once_cell::sync::OnceCell;
 use static_init::dynamic;
 use tokio::{sync::{RwLock, mpsc, oneshot}};
 use tracing::{debug, warn, info, error};
@@ -8,7 +9,6 @@ use std::{path::{Path, PathBuf}, error::Error, time::{SystemTime, Duration}, col
 use rsa::{PublicKey, RsaPrivateKey, RsaPublicKey, PaddingScheme, pkcs1::DecodeRsaPublicKey};
 use sha2::{Sha256, Digest};
 use openssl::{x509::X509, string::OpensslString, asn1::{Asn1Time, Asn1TimeRef}, error::ErrorStack, rand::rand_bytes};
-use vaultrs::{client::{VaultClient, VaultClientSettingsBuilder},pki};
 
 use crate::{errors::SamplyBeamError, MsgTaskRequest, EncryptedMsgTaskRequest, config, beam_id::{ProxyId, BeamId}, config_shared::ConfigCrypto};
 
@@ -18,34 +18,23 @@ const SIGNATURE_LENGTH: u16 = 256;
 pub(crate) struct CertificateCache{
     serial_to_x509: HashMap<Serial, X509>,
     cn_to_serial: HashMap<ProxyId, Serial>,
-    vault_client: VaultClient,
-    pki_realm: String,
-    update_trigger: mpsc::Sender<oneshot::Sender<Result<(),SamplyBeamError>>>,
+    update_trigger: mpsc::Sender<oneshot::Sender<Result<(),SamplyBeamError>>>
+}
+
+#[async_trait]
+pub trait GetCerts: Sync + Send {
+    fn new() -> Result<Self, SamplyBeamError> where Self: Sized;
+    async fn certificate_list(&self) -> Result<Vec<String>,SamplyBeamError>;
+    async fn certificate_by_serial_as_pem(&self, serial: &str) -> Result<String,SamplyBeamError>;
 }
 
 impl CertificateCache {
     pub fn new(update_trigger: mpsc::Sender<oneshot::Sender<Result<(),SamplyBeamError>>>) -> Result<CertificateCache,SamplyBeamError> {
-        let mut certs = Vec::new();
-        if let Some(dir) = &config::CONFIG_SHARED.tls_ca_certificates_dir {
-            for file in std::fs::read_dir(dir).map_err(|e| SamplyBeamError::ConfigurationFailed(format!("Unable to read CA certificates: {}", e)))? {
-                if let Ok(file) = file {
-                    certs.push(file.path().to_str().unwrap().into());
-                }
-            }
-            debug!("Loaded local certificates: {}", certs.join(" "));
-        }
         Ok(Self{
-        serial_to_x509: HashMap::new(),
-        cn_to_serial: HashMap::new(),
-        vault_client: VaultClient::new(
-            VaultClientSettingsBuilder::default()
-                .address(&config::CONFIG_SHARED.pki_address.to_string())
-                .token(&config::CONFIG_SHARED.pki_apikey)
-                .ca_certs(certs)
-                .build()?)?,
-        pki_realm: config::CONFIG_SHARED.pki_realm.clone(),
-        update_trigger
-    })
+            serial_to_x509: HashMap::new(),
+            cn_to_serial: HashMap::new(),
+            update_trigger
+        })
     }
 
     /// Searches cache for a certificate with the given ClientId. If not found, updates cache from central vault. If then still not found, return None
@@ -81,8 +70,10 @@ impl CertificateCache {
             let cache = CERT_CACHE.read().await;
             let cert = cache.serial_to_x509.get(serial);
             match cert { // why is this not done in the second try?
-                Some(certificate) => if x509_date_valid(&certificate).unwrap_or(false) { return cert.cloned(); },
-                None => ()
+                Some(certificate) if x509_date_valid(&certificate).unwrap_or(false) => { 
+                    return Some(certificate.clone());
+                },
+                _ => ()
             }
         }
         Self::update_certificates().await.unwrap_or(()); // requires write lock. We don't care about the result; cache lookup will just fail.
@@ -107,7 +98,7 @@ impl CertificateCache {
 
     async fn update_certificates_mut(&mut self) -> Result<(),SamplyBeamError> {
         info!("Updating certificates ...");
-        let certificate_list = pki::cert::list(&self.vault_client, &self.pki_realm).await?;
+        let certificate_list = CERT_GETTER.get().unwrap().certificate_list().await?;
         let new_certificate_serials: Vec<&String> = {
             certificate_list.iter()
                 .filter(|serial| !self.serial_to_x509.contains_key(*serial))
@@ -116,8 +107,14 @@ impl CertificateCache {
         debug!("Received {} certificates ({} of which were new).", certificate_list.len(), new_certificate_serials.len());
         //TODO Check for validity
         for serial in new_certificate_serials {
-            let certificate = pki::cert::read(&self.vault_client, &self.pki_realm, serial).await?;
-            let opensslcert = X509::from_pem(certificate.certificate.as_bytes())?;
+            debug!("Checking certificate with serial {serial}");
+            let certificate = CERT_GETTER.get().unwrap().certificate_by_serial_as_pem(serial).await;
+            if let Err(e) = certificate {
+                warn!("Could not retrieve certificate for serial {serial}: {}", e);
+                continue;
+            }
+            let certificate = certificate.unwrap();
+            let opensslcert = X509::from_pem(certificate.as_bytes())?;
             let commonnames: Vec<ProxyId> = 
                 opensslcert.subject_name()
                 .entries()
@@ -129,14 +126,17 @@ impl CertificateCache {
                         .expect(&format!("Internal error: Vault returned certificate with invalid common name: {}", x))
                 })
                 .collect();
-
-        if !commonnames.is_empty() && x509_date_valid(&opensslcert)? { // TODO: Check against CA
-            self.serial_to_x509.insert(serial.clone(), opensslcert);
-            self.cn_to_serial.insert(commonnames.first()
-                .expect("Internal error: common names empty; this should not happen")
-                .clone(), serial.clone()); //Emptyness is already checked
+            
+            if commonnames.is_empty() || x509_date_valid(&opensslcert).is_err() {
+                warn!("Certificate with serial {} invalid (no cname or invalid date).", serial);
+            } else { // TODO: Check against CA
+                self.serial_to_x509.insert(serial.clone(), opensslcert);
+                self.cn_to_serial.insert(commonnames.first()
+                    .expect("Internal error: common names empty; this should not happen")
+                    .clone(), serial.clone()); //Emptyness is already checked
+                debug!("Added certificate {} for cname {}", serial, commonnames.first().unwrap());
+            }
         }
-    }
     Ok(())
 
     }
@@ -155,6 +155,19 @@ impl CertificateCache {
         }
         result
     }
+}
+
+static CERT_GETTER: OnceCell<Box<dyn GetCerts>> = OnceCell::new();
+
+pub fn init_cert_getter<G: GetCerts + 'static>(getter: G) {
+    let res = CERT_GETTER.set(Box::new(getter));
+    if res.is_err() {
+        panic!("Internal error: Tried to initialize cert_getter twice");
+    }
+}
+
+pub async fn get_serial_list() -> Result<Vec<String>, SamplyBeamError> {
+    CERT_GETTER.get().unwrap().certificate_list().await
 }
 
 #[dynamic(lazy)]

--- a/shared/src/errors.rs
+++ b/shared/src/errors.rs
@@ -1,7 +1,6 @@
-use std::net::AddrParseError;
+use std::{net::AddrParseError, str::Utf8Error, string::FromUtf8Error};
 
 use openssl::error::ErrorStack;
-use vaultrs::{client::VaultClientSettingsBuilderError, error::ClientError};
 
 #[derive(thiserror::Error, Debug)]
 pub enum SamplyBeamError {
@@ -23,12 +22,16 @@ pub enum SamplyBeamError {
     ConfigurationFailed(String),
     #[error("Internal synchronization error: {0}")]
     InternalSynchronizationError(String),
+    #[error("Error executing HTTP request: {0}")]
+    HttpRequestError(hyper::Error),
     #[error("Error building HTTP request: {0}")]
     HttpRequestBuildError(#[from] http::Error),
     #[error("Problem with HTTP proxy: {0}")]
     HttpProxyProblem(std::io::Error),
     #[error("Invalid Beam ID: {0}")]
-    InvalidBeamId(String)
+    InvalidBeamId(String),
+    #[error("Unable to parse HTTP response: {0}")]
+    HttpParseError(FromUtf8Error)
 }
 
 impl From<AddrParseError> for SamplyBeamError {
@@ -36,18 +39,6 @@ impl From<AddrParseError> for SamplyBeamError {
         let ret = SamplyBeamError::BindAddr(e);
         println!("Building error: {}", ret);
         ret
-    }
-}
-
-impl From<VaultClientSettingsBuilderError> for SamplyBeamError {
-    fn from(e: VaultClientSettingsBuilderError) -> Self {
-        Self::VaultError(format!("Unable to build vault client settings: {}", e))
-    }
-}
-
-impl From<ClientError> for SamplyBeamError {
-    fn from(e: ClientError) -> Self {
-        Self::VaultError(format!("Error in connection to certificate authority: {}", e))
     }
 }
 
@@ -60,5 +51,11 @@ impl From<ErrorStack> for SamplyBeamError {
 impl From<rsa::errors::Error> for SamplyBeamError {
     fn from(e: rsa::errors::Error) -> Self {
         Self::SignEncryptError(e.to_string())
+    }
+}
+
+impl From<hyper::Error> for SamplyBeamError {
+    fn from(e: hyper::Error) -> Self {
+        Self::HttpRequestError(e)
     }
 }

--- a/shared/src/http_proxy.rs
+++ b/shared/src/http_proxy.rs
@@ -11,7 +11,7 @@ use tracing::{debug, info};
 
 use crate::{config, errors::SamplyBeamError, BeamId};
 
-pub fn build_hyper_client(ca_certificates: Vec<X509>) -> Result<Client<ProxyConnector<HttpsConnector<HttpConnector>>>, std::io::Error> {
+pub fn build_hyper_client(ca_certificates: &Vec<X509>) -> Result<Client<ProxyConnector<HttpsConnector<HttpConnector>>>, std::io::Error> {
     let mut http = HttpConnector::new();
     http.set_connect_timeout(Some(Duration::from_secs(1)));
     http.enforce_http(false);
@@ -21,7 +21,7 @@ pub fn build_hyper_client(ca_certificates: Vec<X509>) -> Result<Client<ProxyConn
     let mut proxy_connector = proxy_connector.with_connector(https);
     if ! ca_certificates.is_empty() {
         let mut tls = TlsConnector::builder();
-        for cert in &ca_certificates {
+        for cert in ca_certificates {
             const ERR: &str = "Internal Error: Unable to convert Certificate.";
             let cert = Certificate::from_pem(&cert.to_pem().expect(ERR)).expect(ERR);
             tls.add_root_certificate(cert);
@@ -81,13 +81,13 @@ mod test {
 
     #[tokio::test]
     async fn https() {
-        let client = build_hyper_client(get_certs()).unwrap();
+        let client = build_hyper_client(&get_certs()).unwrap();
         run(HTTPS.parse().unwrap(), client).await;
     }
 
     #[tokio::test]
     async fn http() {
-        let client = build_hyper_client(get_certs()).unwrap();
+        let client = build_hyper_client(&get_certs()).unwrap();
         run(HTTP.parse().unwrap(), client).await;
     }
 


### PR DESCRIPTION
[x] [Retrieve certificates by serial, not cname. Check certificate on startup.](https://github.com/samply/beam/commit/cca328548b3331e2dda56e58f04e5bb00c6fe74f) .
[x] [Have proxies retrive certificates via broker, not via Vault.](https://github.com/samply/beam/commit/4c10fb62b7c0d47a9dc22914e88e6dee689737e2)
[ ] @TKussel Update documentation, dev and demo setup (as Proxies don't need PKI variables anymore)