### PR TITLE
Simplified Cert age selection and added private key check

### DIFF
--- a/shared/src/config_shared.rs
+++ b/shared/src/config_shared.rs
@@ -93,7 +93,7 @@ async fn load_crypto_for_proxy(cli_args: &CliArgs) -> Result<ConfigCrypto, Sampl
     let proxy_id = ProxyId::new(proxy_id)?;
     let publics = get_all_certs_and_clients_by_cname_as_pemstr(&proxy_id).await
         .ok_or_else(|| SamplyBeamError::SignEncryptError("Unable to parse your certificate.".into()))?;
-    let public = crypto::get_best_certificate(publics)
+    let public = crypto::get_best_certificate(&publics, &privkey_rsa)
         .expect("Unable to choose valid, newest certificate for this proxy.");
     let serial = asn_str_to_vault_str(public.cert.serial_number())?;
     privkey_rs256 = privkey_rs256.with_key_id(&serial);

--- a/shared/src/crypto.rs
+++ b/shared/src/crypto.rs
@@ -429,7 +429,7 @@ pub fn load_certificates_from_dir(ca_dir: Option<PathBuf>) -> Result<Vec<X509>, 
 }
 
 /// Checks whether or not a x509 certificate matches a private key by comparing the (public) modulus
-fn is_cert_from_privkey(cert: &X509, key: &RsaPrivateKey)->Result<bool,ErrorStack>{
+fn is_cert_from_privkey(cert: &X509, key: &RsaPrivateKey) -> Result<bool,ErrorStack>{
     let cert_rsa = cert.public_key()?.rsa()?;
     let cert_mod = cert_rsa.n();
     let key_mod = key.n();

--- a/shared/src/crypto.rs
+++ b/shared/src/crypto.rs
@@ -443,6 +443,6 @@ fn is_cert_from_privkey(cert: &X509, key: &RsaPrivateKey) -> Result<bool,ErrorSt
 pub(crate) fn get_best_certificate(publics: &Vec<CryptoPublicPortion>, private_rsa: &RsaPrivateKey) -> Option<CryptoPublicPortion> {
     let mut publics = publics.to_owned();
     publics.retain(|c| is_cert_from_privkey(&c.cert,private_rsa).unwrap_or(false)); // retain certs matching the private cert
-    publics.sort_by(|a,b| a.cert.not_before().compare(b.cert.not_before()).expect("Can not select newest certificate").reverse()); // sort by newest
+    publics.sort_by(|a,b| a.cert.not_before().compare(b.cert.not_before()).expect("Unable to select newest certificate").reverse()); // sort by newest
     publics.first().cloned() // If empty vec --> return None
 }


### PR DESCRIPTION
In addition to previously merged logic handling multiple certificates for one CNAME, this PR checks whether the private key matches the certificate.