### PR TITLE
Add security check with cargo audit

### DIFF
--- a/.github/workflows/rust_security.yml
+++ b/.github/workflows/rust_security.yml
@@ -1,0 +1,11 @@
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Had to add this as a separate, scheduled job since it would fail the pipeline on any error and [does not integrate with Github's security tab](https://github.com/actions-rs/audit-check/issues/170), so error management is somewhat clumsy.