### PR TITLE
Fix CI pipeline

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
 
   build-rust:
     name: Build (Rust)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,14 +61,14 @@ jobs:
             echo "profilestr=--profile $PROFILE" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.arch }}-${{ env.PROFILE }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
           target: ${{ env.rustarch }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.arch }}-${{ env.PROFILE }}
       - name: Build (${{ matrix.arch }})
         uses: actions-rs/cargo@v1
         with:

--- a/dev/beamdev
+++ b/dev/beamdev
@@ -108,11 +108,12 @@ function start_bg {
             if [ "$CODE" == "200" ]; then
                 TRIES=0
             else
-                echo "Waiting for $ADDR ... (${TRIES}th try, last response was: code=$OUT, body=\"$(cat /tmp/body)\")"
+                echo "Waiting for $ADDR ... (try ${TRIES}/120, last response was: code=$OUT, body=\"$(cat /tmp/body 2>/dev/null)\")"
                 sleep 1
-                TRIES+=1
+                ((TRIES=TRIES+1))
                 if [ $TRIES -ge 120 ]; then
-                    echo "ERROR: $ADDR not available after 120 seconds. Giving up."
+                    echo "ERROR: $ADDR not available after 120 seconds. Giving up and printing docker-compose logs."
+                    docker-compose logs
                     exit 5
                 fi
             fi

--- a/dev/beamdev
+++ b/dev/beamdev
@@ -108,11 +108,11 @@ function start_bg {
             if [ "$CODE" == "200" ]; then
                 TRIES=0
             else
-                echo "Waiting for $ADDR ... (try ${TRIES}/120, last response was: code=$OUT, body=\"$(cat /tmp/body 2>/dev/null)\")"
+                echo "Waiting for $ADDR ... (try ${TRIES}/30, last response was: code=$OUT, body=\"$(cat /tmp/body 2>/dev/null)\")"
                 sleep 1
                 ((TRIES=TRIES+1))
-                if [ $TRIES -ge 120 ]; then
-                    echo "ERROR: $ADDR not available after 120 seconds. Giving up and printing docker-compose logs."
+                if [ $TRIES -ge 30 ]; then
+                    echo "ERROR: $ADDR not available after 30 seconds. Giving up and printing docker-compose logs."
                     docker-compose logs
                     exit 5
                 fi

--- a/dev/beamdev
+++ b/dev/beamdev
@@ -100,9 +100,22 @@ function start_bg {
     [ -x ../artifacts/binaries-$ARCH ] || build_rust
     docker-compose up --no-recreate -d
     for ADDR in $P1 $P2; do
-        while [ "$(curl -s -o /dev/null -w '%{response_code}' $ADDR/v1/health)" != "200" ]; do
-            echo "Waiting for $P1 ..."
-            sleep 0.1
+        TRIES=1
+        while [ $TRIES -ne 0 ]; do
+            set +e
+            CODE=$(curl -s -o /tmp/body -w '%{response_code}' $ADDR/v1/health)
+            set -e
+            if [ "$CODE" == "200" ]; then
+                TRIES=0
+            else
+                echo "Waiting for $ADDR ... (${TRIES}th try, last response was: code=$OUT, body=\"$(cat /tmp/body)\")"
+                sleep 1
+                TRIES+=1
+                if [ $TRIES -ge 120 ]; then
+                    echo "ERROR: $ADDR not available after 120 seconds. Giving up."
+                    exit 5
+                fi
+            fi
         done
     done
     echo "Services are up:"


### PR DESCRIPTION
Github has upgraded the `ubuntu-latest` runner from Ubuntu 20.04 to Ubuntu 22.04 (contrary to their documentation, update log is well-hidden here: https://github.com/actions/runner-images/issues/6399), which ships a libssl version incompatible with our distroless base image. This caused all builds to fail.

- Revert build to Ubuntu 20.04 and libssl 1.1
- Also brings some other performance / logging improvements for CI