### PR TITLE
Add User-Agent / Via header (depending on context)

### DIFF
--- a/broker/src/banner.rs
+++ b/broker/src/banner.rs
@@ -1,6 +1,8 @@
+use axum::{response::Response, http::HeaderValue};
+use hyper::header;
 use tracing::info;
 
-pub fn print_banner() {
+pub(crate) fn print_banner() {
     let commit = match env!("GIT_DIRTY") {
         "false" => {
             env!("GIT_COMMIT_SHORT")
@@ -10,4 +12,11 @@ pub fn print_banner() {
         }
     };
     info!("🌈 Samply.Beam ({}) v{} (built {} {}, {}) starting up ...", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"), env!("BUILD_DATE"), env!("BUILD_TIME"), commit);
+}
+
+pub(crate) async fn set_server_header<B>(mut response: Response<B>) -> Response<B> {
+    if ! response.headers_mut().contains_key(header::SERVER) {
+        response.headers_mut().insert(header::SERVER, HeaderValue::from_static(env!("SAMPLY_USER_AGENT")));
+    }
+    response
 }

--- a/broker/src/serve.rs
+++ b/broker/src/serve.rs
@@ -10,14 +10,15 @@ use shared::{EncryptedMsgTaskRequest, EncryptedMsgTaskResult, MsgId, HowLongToBl
 use tokio::{sync::{broadcast::{Sender, Receiver}, RwLock}, time};
 use tracing::{debug, info, trace, warn};
 
-use crate::{serve_tasks, serve_health, serve_pki, crypto::GetCertsFromPki};
+use crate::{serve_tasks, serve_health, serve_pki, crypto::GetCertsFromPki, banner};
 
 pub(crate) async fn serve() -> anyhow::Result<()> {
     let app = 
         serve_tasks::router()
         // .merge(serve_pki::router())
         .merge(serve_pki::router())
-        .merge(serve_health::router());
+        .merge(serve_health::router())
+        .layer(axum::middleware::map_response(banner::set_server_header));
 
     // Graceful shutdown handling
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::mpsc::channel(1);

--- a/proxy/src/banner.rs
+++ b/proxy/src/banner.rs
@@ -15,8 +15,11 @@ pub(crate) fn print_banner() {
 }
 
 pub(crate) async fn set_server_header<B>(mut response: Response<B>) -> Response<B> {
-    if ! response.headers_mut().contains_key(header::SERVER) {
-        response.headers_mut().insert(header::SERVER, HeaderValue::from_static(env!("SAMPLY_USER_AGENT")));
-    }
+    let headers = response.headers_mut();
+    let target_header = match headers.contains_key(header::SERVER) {
+        true => header::VIA, // We're relaying for a proxys
+        false => header::SERVER, // We're answering ourselves
+    };
+    headers.insert(target_header, HeaderValue::from_static(env!("SAMPLY_USER_AGENT")));
     response
 }

--- a/proxy/src/banner.rs
+++ b/proxy/src/banner.rs
@@ -1,6 +1,8 @@
+use axum::{response::Response, http::HeaderValue};
+use hyper::header;
 use tracing::info;
 
-pub fn print_banner() {
+pub(crate) fn print_banner() {
     let commit = match env!("GIT_DIRTY") {
         "false" => {
             env!("GIT_COMMIT_SHORT")
@@ -10,4 +12,11 @@ pub fn print_banner() {
         }
     };
     info!("🌈 Samply.Beam ({}) v{} (built {} {}, {}) starting up ...", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"), env!("BUILD_DATE"), env!("BUILD_TIME"), commit);
+}
+
+pub(crate) async fn set_server_header<B>(mut response: Response<B>) -> Response<B> {
+    if ! response.headers_mut().contains_key(header::SERVER) {
+        response.headers_mut().insert(header::SERVER, HeaderValue::from_static(env!("SAMPLY_USER_AGENT")));
+    }
+    response
 }

--- a/proxy/src/banner.rs
+++ b/proxy/src/banner.rs
@@ -17,7 +17,7 @@ pub(crate) fn print_banner() {
 pub(crate) async fn set_server_header<B>(mut response: Response<B>) -> Response<B> {
     let headers = response.headers_mut();
     let target_header = match headers.contains_key(header::SERVER) {
-        true => header::VIA, // We're relaying for a proxys
+        true => header::VIA, // We're relaying for a broker
         false => header::SERVER, // We're answering ourselves
     };
     headers.insert(target_header, HeaderValue::from_static(env!("SAMPLY_USER_AGENT")));

--- a/proxy/src/serve_tasks.rs
+++ b/proxy/src/serve_tasks.rs
@@ -5,7 +5,7 @@ use httpdate::fmt_http_date;
 use hyper::{
     body,
     client::{connect::Connect, HttpConnector},
-    header, Body, Client, Request, StatusCode, Uri,
+    header, Body, Client, Request, StatusCode, Uri, service::Service,
 };
 use hyper_proxy::ProxyConnector;
 use hyper_tls::HttpsConnector;
@@ -115,7 +115,6 @@ async fn handler_tasks(
     let len = bytes.len();
     let body = Body::from(bytes);
     parts.headers.insert(header::CONTENT_LENGTH, len.into());
-    parts.headers.insert(hyper::header::USER_AGENT, HeaderValue::from_static(env!("SAMPLY_USER_AGENT")));
     let resp = Response::from_parts(parts, body);
 
     Ok(resp)

--- a/shared/src/middleware.rs
+++ b/shared/src/middleware.rs
@@ -1,5 +1,5 @@
 use axum::{middleware::{self, Next}, response::{Response, IntoResponse}, body::HttpBody};
-use http::Request;
+use http::{Request, StatusCode, header};
 use hyper::Body;
 use tracing::{info, warn, span, Level, instrument};
 


### PR DESCRIPTION
* A Broker will always issue a correct "Server" header.
* A Proxy will either
  * issue a "Via" header if relaying a Broker's response
  * issue its own "Server" header if not (e.g. if the Broker was never contacted because ApiKey authentication failed or Broker was unreachable)