### PR TITLE
Added a 30s timeout to the vault cert getter

### DIFF
--- a/broker/src/crypto.rs
+++ b/broker/src/crypto.rs
@@ -79,7 +79,7 @@ impl GetCerts for GetCertsFromPki {
             }?;
         if resp.status() == StatusCode::OK {
             let body_bytes = body::to_bytes(resp.into_body()).await
-            .map_err(|e| SamplyBeamError::VaultError(format!("Cannot retreive certificate {}: {}",serial,e)))?;
+                .map_err(|e| SamplyBeamError::VaultError(format!("Cannot retreive certificate {}: {}",serial,e)))?;
             let body = String::from_utf8(body_bytes.to_vec())
                 .map_err(|e| SamplyBeamError::VaultError(format!("Cannot parse certificate {}: {}",serial,e)))?;
             return Ok(body);
@@ -106,7 +106,7 @@ impl GetCerts for GetCertsFromPki {
             }?;
         if resp.status() == StatusCode::OK {
             let body_bytes = body::to_bytes(resp.into_body()).await
-            .map_err(|e| SamplyBeamError::VaultError(format!("Cannot retreive im-ca certificate: {}",e)))?;
+                .map_err(|e| SamplyBeamError::VaultError(format!("Cannot retreive im-ca certificate: {}",e)))?;
             let body = String::from_utf8(body_bytes.to_vec())
                 .map_err(|e| SamplyBeamError::VaultError(format!("Cannot parse im-ca certificate: {}",e)))?;
             return Ok(body);

--- a/broker/src/crypto.rs
+++ b/broker/src/crypto.rs
@@ -5,7 +5,7 @@ use hyper::{Uri, Request, client::HttpConnector, Client, header, body, StatusCod
 use hyper_proxy::ProxyConnector;
 use hyper_tls::HttpsConnector;
 use serde::{Serialize, Deserialize};
-use shared::{crypto::GetCerts, errors::SamplyBeamError, config, http_proxy::{SamplyHttpClient, self}};
+use shared::{crypto::GetCerts, errors::SamplyBeamError, config, http_client::{SamplyHttpClient, self}};
 use tracing::debug;
 use tokio::time::timeout;
 use std::time::Duration;
@@ -102,7 +102,7 @@ impl GetCerts for GetCertsFromPki {
             }
             debug!("Loaded local certificates: {}", certs.join(" "));
         }
-        let hyper_client = http_proxy::build(&config::CONFIG_SHARED.tls_ca_certificates, Some(Duration::from_secs(30)))
+        let hyper_client = http_client::build(&config::CONFIG_SHARED.tls_ca_certificates, Some(Duration::from_secs(30)))
             .map_err(SamplyBeamError::HttpProxyProblem)?;
         let pki_realm = config::CONFIG_CENTRAL.pki_realm.clone();
 

--- a/broker/src/crypto.rs
+++ b/broker/src/crypto.rs
@@ -39,14 +39,14 @@ impl GetCerts for GetCertsFromPki {
             .header("X-Vault-Token",&config::CONFIG_CENTRAL.pki_token)
             .header("User-Agent", env!("SAMPLY_USER_AGENT"))
             .uri(uri)
-            .body(body::Body::empty()).expect("Can not create Cert List Request"); //TODO Unwrap
+            .body(body::Body::empty()).expect("Cannot create Cert List Request"); //TODO Unwrap
         let request_future = self.hyper_client.request(req);
         let resp = match timeout(Duration::from_millis(30000), request_future).await {
             Ok(result) => match result {
                 Ok(response) => Ok(response),
                 Err(e) => Err(SamplyBeamError::VaultError(format!("Cannot connect to vault: {}",e)))
             },
-            Err(_) => Err(SamplyBeamError::VaultError("Cannoct connect to vault: timeout after 30s".into()))
+            Err(_) => Err(SamplyBeamError::VaultError("Cannot connect to vault: timeout after 30s".into()))
             }?;
         if resp.status() == StatusCode::OK {
             let body_bytes = body::to_bytes(resp.into_body()).await
@@ -75,7 +75,7 @@ impl GetCerts for GetCertsFromPki {
                 Ok(response) => Ok(response),
                 Err(e) => Err(SamplyBeamError::VaultError(format!("Cannot connect to vault: {}",e)))
             },
-            Err(_) => Err(SamplyBeamError::VaultError("Cannoct connect to vault: timeout after 30s".into()))
+            Err(_) => Err(SamplyBeamError::VaultError("Cannot connect to vault: timeout after 30s".into()))
             }?;
         if resp.status() == StatusCode::OK {
             let body_bytes = body::to_bytes(resp.into_body()).await
@@ -102,7 +102,7 @@ impl GetCerts for GetCertsFromPki {
                 Ok(response) => Ok(response),
                 Err(e) => Err(SamplyBeamError::VaultError(format!("Cannot connect to vault: {}",e)))
             },
-            Err(_) => Err(SamplyBeamError::VaultError("Cannoct connect to vault: timeout after 30s".into()))
+            Err(_) => Err(SamplyBeamError::VaultError("Cannot connect to vault: timeout after 30s".into()))
             }?;
         if resp.status() == StatusCode::OK {
             let body_bytes = body::to_bytes(resp.into_body()).await

--- a/proxy/src/crypto.rs
+++ b/proxy/src/crypto.rs
@@ -2,11 +2,11 @@ use axum::{async_trait, Json};
 use hyper::{Client, client::HttpConnector, Uri, StatusCode};
 use hyper_proxy::ProxyConnector;
 use hyper_tls::HttpsConnector;
-use shared::{crypto::GetCerts, errors::SamplyBeamError, config, config_proxy::Config};
+use shared::{crypto::GetCerts, errors::SamplyBeamError, config, config_proxy::Config, http_proxy::SamplyHttpClient};
 use tracing::debug;
 
 pub(crate) struct GetCertsFromBroker {
-    client: Client<ProxyConnector<HttpsConnector<HttpConnector>>>,
+    client: SamplyHttpClient,
     broker_url: Uri
 }
 
@@ -76,7 +76,7 @@ impl GetCerts for GetCertsFromBroker {
 
 pub(crate) fn build_cert_getter(
     config: Config, 
-    client: Client<ProxyConnector<HttpsConnector<HttpConnector>>>
+    client: SamplyHttpClient
 ) -> Result<GetCertsFromBroker,SamplyBeamError> {
     let client = client;
     let broker_url = config.broker_uri;

--- a/proxy/src/crypto.rs
+++ b/proxy/src/crypto.rs
@@ -2,7 +2,7 @@ use axum::{async_trait, Json};
 use hyper::{Client, client::HttpConnector, Uri, StatusCode};
 use hyper_proxy::ProxyConnector;
 use hyper_tls::HttpsConnector;
-use shared::{crypto::GetCerts, errors::SamplyBeamError, config, config_proxy::Config, http_proxy::SamplyHttpClient};
+use shared::{crypto::GetCerts, errors::SamplyBeamError, config, config_proxy::Config, http_client::SamplyHttpClient};
 use tracing::debug;
 
 pub(crate) struct GetCertsFromBroker {

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use hyper::{Client, client::HttpConnector, Uri, Request, StatusCode, body};
 use hyper_proxy::ProxyConnector;
 use hyper_tls::HttpsConnector;
-use shared::http_proxy::{SamplyHttpClient, self};
+use shared::http_client::{SamplyHttpClient, self};
 use tokio_retry::{Retry, strategy::jitter};
 use shared::{config, config_proxy::Config};
 use shared::errors::SamplyBeamError;
@@ -25,7 +25,7 @@ pub async fn main() -> anyhow::Result<()> {
     banner::print_banner();
 
     let config = config::CONFIG_PROXY.clone();
-    let client = http_proxy::build(&config::CONFIG_SHARED.tls_ca_certificates, Some(Duration::from_secs(30)))
+    let client = http_client::build(&config::CONFIG_SHARED.tls_ca_certificates, Some(Duration::from_secs(30)))
         .map_err(SamplyBeamError::HttpProxyProblem)?;
 
     if let Err(err) = get_broker_health(&config, &client).await {

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -1,8 +1,11 @@
 #![allow(unused_imports)]
 
+use std::time::Duration;
+
 use hyper::{Client, client::HttpConnector, Uri, Request, StatusCode, body};
 use hyper_proxy::ProxyConnector;
 use hyper_tls::HttpsConnector;
+use shared::http_proxy::{SamplyHttpClient, self};
 use tokio_retry::{Retry, strategy::jitter};
 use shared::{config, config_proxy::Config};
 use shared::errors::SamplyBeamError;
@@ -22,7 +25,7 @@ pub async fn main() -> anyhow::Result<()> {
     banner::print_banner();
 
     let config = config::CONFIG_PROXY.clone();
-    let client = shared::http_proxy::build_hyper_client(&config::CONFIG_SHARED.tls_ca_certificates)
+    let client = http_proxy::build(&config::CONFIG_SHARED.tls_ca_certificates, Some(Duration::from_secs(30)))
         .map_err(SamplyBeamError::HttpProxyProblem)?;
 
     if let Err(err) = get_broker_health(&config, &client).await {
@@ -42,7 +45,7 @@ pub async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn init_crypto(config: Config, client: Client<ProxyConnector<HttpsConnector<HttpConnector>>>) -> Result<(),SamplyBeamError> {
+async fn init_crypto(config: Config, client: SamplyHttpClient) -> Result<(),SamplyBeamError> {
     shared::crypto::init_cert_getter(crypto::build_cert_getter(config.clone(), client.clone())?);
     shared::crypto::init_ca_chain().await;
     
@@ -59,7 +62,7 @@ async fn init_crypto(config: Config, client: Client<ProxyConnector<HttpsConnecto
     Ok(())
 }
 
-async fn get_broker_health(config: &Config, client: &Client<ProxyConnector<HttpsConnector<HttpConnector>>>) -> Result<(), SamplyBeamError> {
+async fn get_broker_health(config: &Config, client: &SamplyHttpClient) -> Result<(), SamplyBeamError> {
     let mut counter: u32 = 0;
     let function = ||{
         let uri = Uri::builder().scheme(config.broker_uri.scheme().unwrap().as_str()).authority(config.broker_uri.authority().unwrap().to_owned()).path_and_query("/v1/health").build().map_err(|e| SamplyBeamError::HttpRequestBuildError(e)).unwrap(); // TODO Unwrap

--- a/proxy/src/serve.rs
+++ b/proxy/src/serve.rs
@@ -3,12 +3,12 @@ use std::fmt::Write;
 use hyper::{Client, client::HttpConnector};
 use hyper_proxy::ProxyConnector;
 use hyper_tls::HttpsConnector;
-use shared::{config, errors::SamplyBeamError, config_shared, config_proxy};
+use shared::{config, errors::SamplyBeamError, config_shared, config_proxy, http_proxy::SamplyHttpClient};
 use tracing::{info, debug, warn, error};
 
 use crate::{serve_health, serve_tasks};
 
-pub(crate) async fn serve(config: config_proxy::Config, client: Client<ProxyConnector<HttpsConnector<HttpConnector>>>) -> anyhow::Result<()> {
+pub(crate) async fn serve(config: config_proxy::Config, client: SamplyHttpClient) -> anyhow::Result<()> {
     let router_tasks = serve_tasks::router(&client);
 
     let router_health = serve_health::router();

--- a/proxy/src/serve.rs
+++ b/proxy/src/serve.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use hyper::{Client, client::HttpConnector};
 use hyper_proxy::ProxyConnector;
 use hyper_tls::HttpsConnector;
-use shared::{config, errors::SamplyBeamError, config_shared, config_proxy, http_proxy::SamplyHttpClient};
+use shared::{config, errors::SamplyBeamError, config_shared, config_proxy, http_client::SamplyHttpClient};
 use tracing::{info, debug, warn, error};
 
 use crate::{serve_health, serve_tasks};

--- a/proxy/src/serve_tasks.rs
+++ b/proxy/src/serve_tasks.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 use shared::{
     beam_id::{AppId, AppOrProxyId, ProxyId}, config::{self, CONFIG_PROXY}, config_proxy, crypto_jwt, errors::SamplyBeamError, EncMsg, DecMsg,
     EncryptedMsgTaskRequest, EncryptedMsgTaskResult, Msg, MsgEmpty, MsgId, MsgSigned,
-    MsgTaskRequest, MsgTaskResult, crypto,
+    MsgTaskRequest, MsgTaskResult, crypto, http_proxy::SamplyHttpClient,
 };
 use tracing::{debug, error, warn};
 
@@ -23,11 +23,11 @@ use crate::auth::AuthenticatedApp;
 
 #[derive(Clone, FromRef)]
 struct TasksState {
-    client: Client<ProxyConnector<HttpsConnector<HttpConnector>>>,
+    client: SamplyHttpClient,
     config: config_proxy::Config
 }
 
-pub(crate) fn router(client: &Client<ProxyConnector<HttpsConnector<HttpConnector>>>) -> Router {
+pub(crate) fn router(client: &SamplyHttpClient) -> Router {
     let config = config::CONFIG_PROXY.clone();
     let state = TasksState {
         client: client.clone(),
@@ -57,7 +57,7 @@ const ERR_FAKED_FROM: (StatusCode, &str) = (
 );
 
 async fn handler_tasks(
-    State(client): State<Client<ProxyConnector<HttpsConnector<HttpConnector>>>>,
+    State(client): State<SamplyHttpClient>,
     State(config): State<config_proxy::Config>,
     AuthenticatedApp(sender): AuthenticatedApp,
     req: Request<Body>,

--- a/proxy/src/serve_tasks.rs
+++ b/proxy/src/serve_tasks.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 use shared::{
     beam_id::{AppId, AppOrProxyId, ProxyId}, config::{self, CONFIG_PROXY}, config_proxy, crypto_jwt, errors::SamplyBeamError, EncMsg, DecMsg,
     EncryptedMsgTaskRequest, EncryptedMsgTaskResult, Msg, MsgEmpty, MsgId, MsgSigned,
-    MsgTaskRequest, MsgTaskResult, crypto, http_proxy::SamplyHttpClient,
+    MsgTaskRequest, MsgTaskResult, crypto, http_client::SamplyHttpClient,
 };
 use tracing::{debug, error, warn};
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -25,6 +25,7 @@ hyper = { version = "0.14.19", features = ["full"] }
 hyper-tls = "0.5.0"
 hyper-proxy = "0.9.1"
 mz-http-proxy = { version = "0.1.0", features = ["hyper"] }
+hyper-timeout = "0.4"
 
 # Logging
 tracing = "0.1.35"

--- a/shared/src/errors.rs
+++ b/shared/src/errors.rs
@@ -1,6 +1,7 @@
 use std::{net::AddrParseError, str::Utf8Error, string::FromUtf8Error};
 
 use openssl::error::ErrorStack;
+use tokio::time::error::Elapsed;
 
 #[derive(thiserror::Error, Debug)]
 pub enum SamplyBeamError {
@@ -33,7 +34,9 @@ pub enum SamplyBeamError {
     #[error("Unable to parse HTTP response: {0}")]
     HttpParseError(FromUtf8Error),
     #[error("X509 certificate invalid: {0}")]
-    CertificateError(&'static str)
+    CertificateError(&'static str),
+    #[error("Timeout executing HTTP request: {0}")]
+    HttpTimeoutError(Elapsed),
 }
 
 impl From<AddrParseError> for SamplyBeamError {

--- a/shared/src/http_client.rs
+++ b/shared/src/http_client.rs
@@ -77,7 +77,7 @@ mod test {
     use hyper_tls::HttpsConnector;
     use openssl::x509::X509;
 
-    use crate::http_proxy::SamplyHttpClient;
+    use crate::http_client::{SamplyHttpClient, self};
 
     const HTTP: &str = "http://ip-api.com/json";
     const HTTPS: &str = "https://ifconfig.me/";
@@ -93,13 +93,13 @@ mod test {
 
     #[tokio::test]
     async fn https() {
-        let client = SamplyHttpClient::build(&get_certs(), None).unwrap();
+        let client = http_client::build(&get_certs(), None).unwrap();
         run(HTTPS.parse().unwrap(), client).await;
     }
 
     #[tokio::test]
     async fn http() {
-        let client = SamplyHttpClient::build(&get_certs(), None).unwrap();
+        let client = http_client::build(&get_certs(), None).unwrap();
         run(HTTP.parse().unwrap(), client).await;
     }
 
@@ -109,7 +109,7 @@ mod test {
             .body(body::Body::empty())
             .unwrap();
 
-        let mut resp = client.request_with_timeout(req).await.unwrap();
+        let mut resp = client.request(req).await.unwrap();
 
         let resp_string = body::to_bytes(resp.body_mut()).await.unwrap();
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -48,7 +48,7 @@ pub mod config_broker;
 pub mod config_proxy;
 
 pub mod beam_id;
-pub mod http_proxy;
+pub mod http_client;
 pub mod middleware;
 
 pub mod examples;


### PR DESCRIPTION
In case of communication errors between broker and vault, the broker might lock up, as the `hyper` crate does not provide a timeout mechanism for requests.
Using `tokio`'s timout mechanism for futures, this PR introduces a 30 second timeout.