### PR TITLE
Print startup messages directly on startup.

### DIFF
--- a/broker/src/main.rs
+++ b/broker/src/main.rs
@@ -17,6 +17,8 @@ use tracing::info;
 #[tokio::main]
 pub async fn main() -> anyhow::Result<()> {    
     shared::config::prepare_env();
+    shared::logger::init_logger()?;
+    banner::print_banner();
 
     let cert_getter = crypto::build_cert_getter()?;
     shared::crypto::init_cert_getter(cert_getter);
@@ -24,9 +26,6 @@ pub async fn main() -> anyhow::Result<()> {
     #[cfg(debug_assertions)]
     if shared::examples::print_example_objects() { return Ok(()); }
     
-    shared::logger::init_logger()?;
-    banner::print_banner();
-
     let _ = config::CONFIG_CENTRAL.bind_addr; // Initialize config
 
     serve::serve().await?;

--- a/broker/src/serve.rs
+++ b/broker/src/serve.rs
@@ -31,7 +31,7 @@ pub(crate) async fn serve() -> anyhow::Result<()> {
         }
     });
 
-    info!("Listening for requests on {}", config::CONFIG_CENTRAL.bind_addr);
+    info!("Startup complete. Listening for requests on {}", config::CONFIG_CENTRAL.bind_addr);
     axum::Server::bind(&config::CONFIG_CENTRAL.bind_addr)
         .serve(app.into_make_service())
         .with_graceful_shutdown(async {

--- a/proxy/src/serve.rs
+++ b/proxy/src/serve.rs
@@ -32,7 +32,7 @@ pub(crate) async fn serve(config: config_proxy::Config, client: SamplyHttpClient
 
     let mut apps_joined = String::new();
     config.api_keys.keys().for_each(|k| write!(apps_joined, "{} ", k.to_string().split('.').next().unwrap()).unwrap());
-    info!("This is Proxy {} listening on {}. {} apps are known: {}", config.proxy_id, config.bind_addr, config.api_keys.len(), apps_joined);
+    info!("Startup complete. This is Proxy {} listening on {}. {} apps are known: {}", config.proxy_id, config.bind_addr, config.api_keys.len(), apps_joined);
     
     axum::Server::bind(&config.bind_addr)
         .serve(app.into_make_service())


### PR DESCRIPTION
In some edge cases, the Broker was unable to print log messages since the logger was not initialized, yet. Now, logging is initialized immediately and the banner (baked in at compile time so it should always be there) is printed right when the program starts.