### PR TITLE
Improve local build

### DIFF
--- a/Dockerfile.ci.broker
+++ b/Dockerfile.ci.broker
@@ -1,11 +1,13 @@
 # This assumes binaries are present, see COPY directive.
 
+ARG IMGNAME=gcr.io/distroless/cc
+
 FROM alpine AS chmodder
 ARG TARGETARCH
 COPY /artifacts/binaries-$TARGETARCH/broker /app/
 RUN chmod +x /app/*
 
-FROM gcr.io/distroless/cc
+FROM ${IMGNAME}
 #ARG COMPONENT
 #ARG TARGETARCH
 #COPY /artifacts/binaries-$TARGETARCH/$COMPONENT /usr/local/bin/

--- a/Dockerfile.ci.proxy
+++ b/Dockerfile.ci.proxy
@@ -1,11 +1,13 @@
 # This assumes binaries are present, see COPY directive.
 
+ARG IMGNAME=gcr.io/distroless/cc
+
 FROM alpine AS chmodder
 ARG TARGETARCH
 COPY /artifacts/binaries-$TARGETARCH/proxy /app/
 RUN chmod +x /app/*
 
-FROM gcr.io/distroless/cc
+FROM ${IMGNAME}
 #ARG COMPONENT
 #ARG TARGETARCH
 #COPY /artifacts/binaries-$TARGETARCH/$COMPONENT /usr/local/bin/

--- a/Dockerfile.non-ci.broker
+++ b/Dockerfile.non-ci.broker
@@ -1,8 +1,0 @@
-FROM rust:bullseye AS builder
-WORKDIR /usr/src/app
-COPY . .
-RUN cargo build --bin broker --release
-
-FROM gcr.io/distroless/cc
-COPY --from=builder /usr/src/app/target/release/broker /usr/local/bin/
-ENTRYPOINT [ "/usr/local/bin/broker" ]

--- a/Dockerfile.non-ci.proxy
+++ b/Dockerfile.non-ci.proxy
@@ -1,8 +1,0 @@
-FROM rust:bullseye AS builder
-WORKDIR /usr/src/app
-COPY . . 
-RUN cargo build --bin proxy --release
-
-FROM gcr.io/distroless/cc
-COPY --from=builder /usr/src/app/target/release/proxy /usr/local/bin/
-ENTRYPOINT [ "/usr/local/bin/proxy" ]

--- a/dev/beamdev
+++ b/dev/beamdev
@@ -39,6 +39,18 @@ export P2="http://localhost:8082" # for scripts
 
 export ARCH=$(docker version --format "{{.Server.Arch}}")
 
+function image_for_docker() {
+     # Pick the correct Ubuntu version for the Docker image,
+     # so the locally-built rust binary works regarding libssl
+     if [[ "$(pkg-config --modversion libssl)" =~ ^3.* ]]; then
+          echo "ubuntu:slim" # Use libssl3
+     else
+          echo -n "" # Don't change (uses libssl1.1)
+     fi
+}
+
+export IMGNAME="$(image_for_docker)"
+
 function check_prereqs() {
      set +e
      if [[ "$(curl --version)" != *" libcurl/"* ]]; then
@@ -56,22 +68,46 @@ function check_prereqs() {
      set -e
 }
 
-function build_rust() {
+function build() {
+    BUILD_DOCKER=0
     BACK=$(pwd)
     cd $SD/..
     BUILD=$(cargo build --message-format=json)
-    BROKER=$(echo $BUILD | jq 'select(.executable != null)' |jq -r 'select(.target.name == "broker")' | jq -r .executable)
-    PROXY=$(echo $BUILD | jq 'select(.executable != null)' | jq -r 'select(.target.name == "proxy")' | jq -r .executable)
-    mkdir -p artifacts/binaries-$ARCH
-    rsync "$BROKER" "$PROXY" artifacts/binaries-$ARCH/
+    if echo $BUILD | jq 'select(.fresh==false)' | grep -q 'fresh'; then
+        echo "Will rebuild docker image due to changes in rust binaries."
+        BUILD_DOCKER=1
+    fi
+    [ -x ./artifacts/binaries-$ARCH ] || {
+        echo "Will rebuild docker image since binaries had not been there."
+        BUILD_DOCKER=1
+    }
+    if [ -z "$(docker images -q samply/beam-broker:$TAG)" ] || [ -z "$(docker images -q samply/beam-proxy:$TAG)" ]; then
+        echo "Will rebuild docker image since it is missing."
+        BUILD_DOCKER=1
+    fi
+    if [ $BUILD_DOCKER -eq 1 ]; then
+        BROKER=$(echo $BUILD | jq 'select(.executable != null)' |jq -r 'select(.target.name == "broker")' | jq -r .executable)
+        PROXY=$(echo $BUILD | jq 'select(.executable != null)' | jq -r 'select(.target.name == "proxy")' | jq -r .executable)
+        mkdir -p artifacts/binaries-$ARCH
+        rsync "$BROKER" "$PROXY" artifacts/binaries-$ARCH/
+        build_docker
+    else
+        echo "Not rebuilding docker image since nothing has changed."
+    fi
     cd $BACK
 }
 
 function build_docker() {
-    BACK=$(pwd)
+    BACK2=$(pwd)
     cd $SD
-    docker-compose build --build-arg TARGETARCH=$ARCH
-    cd $BACK
+    echo "IMGNAME=$IMGNAME PRE"
+    if [ -z "$IMGNAME" ]; then
+        docker-compose build --build-arg TARGETARCH=$ARCH --build-arg TAG=$TAG
+    else
+        docker-compose build --build-arg TARGETARCH=$ARCH --build-arg TAG=$TAG --build-arg IMGNAME=$IMGNAME
+    fi
+    echo "IMGNAME=$IMGNAME POST"
+    cd $BACK2
 }
 
 function clean() {
@@ -83,16 +119,16 @@ function start {
     clean
     pki/pki devsetup
     echo "$VAULT_TOKEN" > ./pki/pki.secret
-    [ -x ../artifacts/binaries-$ARCH ] || (build_rust && build_docker)
-    docker-compose up --no-recreate --abort-on-container-exit
+    build
+    docker-compose up --no-recreate --abort-on-container-exit --no-build
 }
 
 function start_bg {
     clean
     pki/pki devsetup
     echo "$VAULT_TOKEN" > ./pki/pki.secret
-    [ -x ../artifacts/binaries-$ARCH ] || (build_rust && build_docker)
-    docker-compose up --no-recreate -d
+    build
+    docker-compose up --no-recreate -d --no-build
     for ADDR in $P1 $P2; do
         TRIES=1
         while [ $TRIES -ne 0 ]; do

--- a/dev/beamdev
+++ b/dev/beamdev
@@ -100,13 +100,11 @@ function build() {
 function build_docker() {
     BACK2=$(pwd)
     cd $SD
-    echo "IMGNAME=$IMGNAME PRE"
     if [ -z "$IMGNAME" ]; then
-        docker-compose build --build-arg TARGETARCH=$ARCH --build-arg TAG=$TAG
+        docker-compose build --build-arg TARGETARCH=$ARCH
     else
-        docker-compose build --build-arg TARGETARCH=$ARCH --build-arg TAG=$TAG --build-arg IMGNAME=$IMGNAME
+        docker-compose build --build-arg TARGETARCH=$ARCH --build-arg IMGNAME=$IMGNAME
     fi
-    echo "IMGNAME=$IMGNAME POST"
     cd $BACK2
 }
 
@@ -120,7 +118,7 @@ function start {
     pki/pki devsetup
     echo "$VAULT_TOKEN" > ./pki/pki.secret
     build
-    docker-compose up --no-recreate --abort-on-container-exit --no-build
+    docker-compose up --no-build --no-recreate --abort-on-container-exit
 }
 
 function start_bg {
@@ -128,7 +126,7 @@ function start_bg {
     pki/pki devsetup
     echo "$VAULT_TOKEN" > ./pki/pki.secret
     build
-    docker-compose up --no-recreate -d --no-build
+    docker-compose up --no-build --no-recreate -d
     for ADDR in $P1 $P2; do
         TRIES=1
         while [ $TRIES -ne 0 ]; do

--- a/dev/beamdev
+++ b/dev/beamdev
@@ -43,7 +43,7 @@ function image_for_docker() {
      # Pick the correct Ubuntu version for the Docker image,
      # so the locally-built rust binary works regarding libssl
      if [[ "$(pkg-config --modversion libssl)" =~ ^3.* ]]; then
-          echo "ubuntu:slim" # Use libssl3
+          echo "ubuntu:latest" # Use libssl3
      else
           echo -n "" # Don't change (uses libssl1.1)
      fi

--- a/dev/beamdev
+++ b/dev/beamdev
@@ -262,7 +262,7 @@ export TAG=${TAG:-localbuild}
 
 case "$1" in
   build)
-    build_rust && build_docker
+    build
     ;;
   start)
     start

--- a/dev/pki/pki
+++ b/dev/pki/pki
@@ -13,7 +13,7 @@ export BROKER_ID=$(echo $PROXY1_ID | cut -d '.' -f 2-)
 export VAULT_ADDR=http://127.0.0.1:8200
 
 function start() {
-     docker-compose up -d vault
+     docker-compose up -d vault --no-build
 }
 
 function clean() {

--- a/dev/pki/pki
+++ b/dev/pki/pki
@@ -13,7 +13,7 @@ export BROKER_ID=$(echo $PROXY1_ID | cut -d '.' -f 2-)
 export VAULT_ADDR=http://127.0.0.1:8200
 
 function start() {
-     docker-compose up -d vault --no-build
+     docker-compose up -d --no-build vault
 }
 
 function clean() {


### PR DESCRIPTION
- Make build work on libssl1.1- and libssl3-based dev systems (e.g. Ubuntu 20.04, 22.04)
- Don't rebuild docker image only if Rust sources haven't changed
- Do re-build docker image if Rust sources have changed

Please verify, using `./dev/beamdev start` and `./dev/test noci` and/or `./dev/test ci`:
- [ ] Works on my current dev setup
- [ ] Works on fresh Ubuntu 20.04
- [ ] Works on fresh Ubuntu 22.04