### PR TITLE
Graceful shutdown in Docker environments

### DIFF
--- a/broker/src/serve.rs
+++ b/broker/src/serve.rs
@@ -20,24 +20,10 @@ pub(crate) async fn serve(health: Arc<RwLock<Health>>) -> anyhow::Result<()> {
         .layer(axum::middleware::from_fn(shared::middleware::log))
         .layer(axum::middleware::map_response(banner::set_server_header));
 
-    // Graceful shutdown handling
-    let (shutdown_tx, mut shutdown_rx) = tokio::sync::mpsc::channel(1);
-
-    tokio::spawn(async move {
-        tokio::signal::ctrl_c().await
-                .expect("Unable to listen for Ctrl+C for graceful shutdown");
-        if shutdown_tx.blocking_send(()).is_err() {
-            warn!("Unable to send signal for clean shutdown... ignoring.");
-        }
-    });
-
     info!("Startup complete. Listening for requests on {}", config::CONFIG_CENTRAL.bind_addr);
     axum::Server::bind(&config::CONFIG_CENTRAL.bind_addr)
         .serve(app.into_make_service_with_connect_info::<SocketAddr>())
-        .with_graceful_shutdown(async {
-            shutdown_rx.recv().await;
-            info!("Shutting down.");
-        })
+        .with_graceful_shutdown(shared::graceful_shutdown::wait_for_signal())
         .await?;
     Ok(())
 }

--- a/shared/src/graceful_shutdown.rs
+++ b/shared/src/graceful_shutdown.rs
@@ -3,9 +3,12 @@ use std::time::Duration;
 use tokio::signal::unix::{signal,SignalKind};
 use tracing::info;
 
+#[cfg(unix)]
 pub async fn wait_for_signal() {
-    let mut sigterm = signal(SignalKind::terminate()).unwrap();
-    let mut sigkill = signal(SignalKind::interrupt()).unwrap();
+    let mut sigterm = signal(SignalKind::terminate())
+        .expect("Unable to register shutdown handler; are you running a Unix-based OS?");
+    let mut sigkill = signal(SignalKind::interrupt())
+        .expect("Unable to register shutdown handler; are you running a Unix-based OS?");
     let signal = tokio::select! {
         _ = sigterm.recv() => "SIGTERM",
         _ = sigkill.recv() => "SIGKILL"
@@ -13,4 +16,12 @@ pub async fn wait_for_signal() {
     // The following does not print in docker-compose setups but it does when run individually.
     // Probably a docker-compose error.
     info!("Received signal ({signal}) - shutting down gracefully.");
+}
+
+#[cfg(windows)]
+pub async fn wait_for_signal() {
+    if let Err(e) = tokio::signal::ctrl_c().await {
+        panic!("Unable to register shutdown handler: {e}.");
+    }
+    info!("Received shutdown signal - shutting down gracefully.");
 }

--- a/shared/src/graceful_shutdown.rs
+++ b/shared/src/graceful_shutdown.rs
@@ -1,0 +1,16 @@
+use std::time::Duration;
+
+use tokio::signal::unix::{signal,SignalKind};
+use tracing::info;
+
+pub async fn wait_for_signal() {
+    let mut sigterm = signal(SignalKind::terminate()).unwrap();
+    let mut sigkill = signal(SignalKind::interrupt()).unwrap();
+    let signal = tokio::select! {
+        _ = sigterm.recv() => "SIGTERM",
+        _ = sigkill.recv() => "SIGKILL"
+    };
+    // The following does not print in docker-compose setups but it does when run individually.
+    // Probably a docker-compose error.
+    info!("Received signal ({signal}) - shutting down gracefully.");
+}

--- a/shared/src/graceful_shutdown.rs
+++ b/shared/src/graceful_shutdown.rs
@@ -7,11 +7,11 @@ use tracing::info;
 pub async fn wait_for_signal() {
     let mut sigterm = signal(SignalKind::terminate())
         .expect("Unable to register shutdown handler; are you running a Unix-based OS?");
-    let mut sigkill = signal(SignalKind::interrupt())
+    let mut sigint = signal(SignalKind::interrupt())
         .expect("Unable to register shutdown handler; are you running a Unix-based OS?");
     let signal = tokio::select! {
         _ = sigterm.recv() => "SIGTERM",
-        _ = sigkill.recv() => "SIGKILL"
+        _ = sigint.recv() => "SIGINT"
     };
     // The following does not print in docker-compose setups but it does when run individually.
     // Probably a docker-compose error.

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -50,6 +50,7 @@ pub mod config_proxy;
 pub mod beam_id;
 pub mod http_client;
 pub mod middleware;
+pub mod graceful_shutdown;
 
 pub mod examples;
 


### PR DESCRIPTION
This will make Beam quit a) gracefully and b) faster in Docker-based environments, where some signals are not forwarded into containers.