### PR TITLE
Log shows from when request was Authorized

### DIFF
--- a/dev/test_5_retrieve_via_to.sh
+++ b/dev/test_5_retrieve_via_to.sh
@@ -14,7 +14,7 @@ success
 
 testing Create task TASK2_BY_A1P1_FOR_A1P2
 
-TASK2_BY_A1P1_FOR_A1P2="$(echo "$TASK2_BY_A1P1_FOR_A1P2" | task_with_ttl 3)"
+TASK2_BY_A1P1_FOR_A1P2="$(echo "$TASK2_BY_A1P1_FOR_A1P2" | task_with_ttl 4)"
 RET=$(echo $TASK2_BY_A1P1_FOR_A1P2 | curl_post $APP1_P1 -v $P1/v1/tasks)
 CODE=$(echo $RET | jq -r .response_code)
 
@@ -65,7 +65,7 @@ success
 
 testing After expiration, we should be able to re-create the same task
 
-TASK_BY_A1P1_FOR_A1P2="$(echo "$TASK2_BY_A1P1_FOR_A1P2" | task_with_ttl 4)"
+TASK_BY_A1P1_FOR_A1P2="$(echo "$TASK2_BY_A1P1_FOR_A1P2" | task_with_ttl 10)"
 RET=$(echo $TASK_BY_A1P1_FOR_A1P2 | curl_post $APP1_P1 -v $P1/v1/tasks)
 CODE=$(echo $RET | jq -r .response_code)
 

--- a/proxy/src/crypto.rs
+++ b/proxy/src/crypto.rs
@@ -1,23 +1,37 @@
-use axum::{async_trait, Json};
-use hyper::{Client, client::HttpConnector, Uri, StatusCode};
+use axum::{async_trait, Json, body::Bytes, response::Response, http::request};
+use hyper::{Client, client::HttpConnector, Uri, StatusCode, Request, Method};
 use hyper_proxy::ProxyConnector;
 use hyper_tls::HttpsConnector;
-use shared::{crypto::GetCerts, errors::{SamplyBeamError, CertificateInvalidReason}, config, config_proxy::Config, http_client::SamplyHttpClient};
+use shared::{crypto::GetCerts, errors::{SamplyBeamError, CertificateInvalidReason}, config, config_proxy::Config, http_client::SamplyHttpClient, MsgEmpty, beam_id::AppOrProxyId};
 use tracing::{debug, warn, info};
+
+use crate::serve_tasks::sign_request;
 
 pub(crate) struct GetCertsFromBroker {
     client: SamplyHttpClient,
-    broker_url: Uri
+    config: Config
 }
 
 impl GetCertsFromBroker {
-    async fn query(&self, path: &str) -> Result<String,SamplyBeamError> {
+    async fn request(&self, path: &str) -> Result<Response<hyper::Body>, SamplyBeamError> {
         let uri = Uri::builder()
-            .scheme(self.broker_url.scheme().unwrap().to_owned())
-            .authority(self.broker_url.authority().unwrap().to_owned())
+            .scheme(self.config.broker_uri.scheme().unwrap().to_owned())
+            .authority(self.config.broker_uri.authority().unwrap().to_owned())
             .path_and_query(path)
             .build()?;
-        let mut req = self.client.get(uri).await?;
+
+        let body = serde_json::to_value(MsgEmpty { from: AppOrProxyId::ProxyId(self.config.proxy_id.clone()) }).expect("Emptymsg faild to serialize");
+        let (parts, body) = Request::builder().method(Method::GET).uri(&uri).body(body).expect("To build request successfully").into_parts();
+        let req = sign_request(body, parts, &self.config, &uri, AppOrProxyId::ProxyId(self.config.proxy_id.clone()))
+            .await
+            .map_err(|(_, msg)| {
+                SamplyBeamError::SignEncryptError(msg.into())
+            })?;
+        Ok(self.client.request(req).await?)
+    }
+
+    async fn query(&self, path: &str) -> Result<String,SamplyBeamError> {
+        let mut req = self.request(path).await?;
         let resp = hyper::body::to_bytes(req.body_mut()).await?;
         let resp = String::from_utf8(resp.to_vec())
             .map_err(|e| SamplyBeamError::HttpParseError(e))?;
@@ -33,12 +47,7 @@ impl GetCertsFromBroker {
     }
 
     async fn query_vec(&self, path: &str) -> Result<Vec<String>,SamplyBeamError> {
-        let uri = Uri::builder()
-            .scheme(self.broker_url.scheme().unwrap().to_owned())
-            .authority(self.broker_url.authority().unwrap().to_owned())
-            .path_and_query(path)
-            .build()?;
-        let mut req = self.client.get(uri).await?;
+        let mut req = self.request(path).await?;
         let resp = hyper::body::to_bytes(req.body_mut()).await?;
         let json: Vec<String> = serde_json::from_slice(&resp)
             .map_err(|e| SamplyBeamError::VaultOtherError(format!("Unable to parse vault reply: {}", e)))?;
@@ -76,11 +85,11 @@ pub(crate) fn build_cert_getter(
     client: SamplyHttpClient
 ) -> Result<GetCertsFromBroker,SamplyBeamError> {
     let client = client;
-    let broker_url = config.broker_uri;
+    let broker_url = config.broker_uri.clone();
     let _ = broker_url.scheme().ok_or(SamplyBeamError::ConfigurationFailed("Broker URL invalid.".into()))?;
     let _ = broker_url.authority().ok_or(SamplyBeamError::ConfigurationFailed("Broker URL invalid.".into()))?;
     // let broker_builder = Uri::builder()
     //     .scheme(scheme)
     //     .authority(authority);
-    Ok(GetCertsFromBroker { client, broker_url })
+    Ok(GetCertsFromBroker { client, config })
 }

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -55,6 +55,7 @@ pub async fn main() -> anyhow::Result<()> {
 }
 
 async fn init_crypto(config: Config, client: SamplyHttpClient) -> Result<(),SamplyBeamError> {
+    shared::config_shared::load_private_crypto_for_proxy()?;
     shared::crypto::init_cert_getter(crypto::build_cert_getter(config.clone(), client.clone())?);
     shared::crypto::init_ca_chain().await?;
     
@@ -66,7 +67,7 @@ async fn init_crypto(config: Config, client: SamplyHttpClient) -> Result<(),Samp
             )
             .ok())
         .collect();
-    let (serial, cname) = shared::config_shared::init_crypto_for_proxy().await?;
+    let (serial, cname) = shared::config_shared::init_public_crypto_for_proxy().await?;
     if cname != config.proxy_id.to_string() {
         return Err(SamplyBeamError::ConfigurationFailed(format!("Unable to retrieve a certificate matching your Proxy ID. Expected {}, got {}. Please check your configuration", cname, config.proxy_id.to_string())));
     }

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -77,7 +77,13 @@ async fn init_crypto(config: Config, client: SamplyHttpClient) -> Result<(),Samp
 }
 
 async fn get_broker_health(config: &Config, client: &SamplyHttpClient) -> Result<(), SamplyBeamError> {
-    let uri = Uri::builder().scheme(config.broker_uri.scheme().unwrap().as_str()).authority(config.broker_uri.authority().unwrap().to_owned()).path_and_query("/v1/health").build().map_err(|e| SamplyBeamError::HttpRequestBuildError(e)).unwrap(); // TODO Unwrap
+    let uri = Uri::builder()
+        .scheme(config.broker_uri.scheme().expect("Config broker uri to have valid scheme").as_str())
+        .authority(config.broker_uri.authority().expect("Config broker uri to have valid authority").to_owned())
+        .path_and_query("/v1/health")
+        .build()
+        .map_err(|e| SamplyBeamError::HttpRequestBuildError(e))
+        .expect("Uri to be constructed correctly");
 
     let resp = retry_notify(
         backoff::ExponentialBackoffBuilder::default()
@@ -89,7 +95,8 @@ async fn get_broker_health(config: &Config, client: &SamplyHttpClient) -> Result
                 .method(Method::GET)
                 .uri(&uri)
                 .header(hyper::header::USER_AGENT, env!("SAMPLY_USER_AGENT"))
-                .body(body::Body::empty()).unwrap(); //TODO Unwrap
+                .body(body::Body::empty())
+                .expect("Request to be constructed correctly");
             Ok(client.request(req).await?)
         },
         |err, b: Duration| {

--- a/proxy/src/serve_tasks.rs
+++ b/proxy/src/serve_tasks.rs
@@ -295,7 +295,7 @@ async fn handler_tasks_stream(
 }
 
 // TODO: This could be a middleware
-async fn sign_request(
+pub async fn sign_request(
     body: Value,
     mut parts: Parts,
     config: &config_proxy::Config,

--- a/shared/src/beam_id.rs
+++ b/shared/src/beam_id.rs
@@ -194,6 +194,15 @@ pub enum AppOrProxyId {
     ProxyId(ProxyId),
 }
 
+impl AppOrProxyId {
+    pub fn get_proxy_id(&self) -> ProxyId {
+        match self {
+            AppOrProxyId::AppId(app) => app.proxy_id(),
+            AppOrProxyId::ProxyId(proxy) => proxy.clone() 
+        }
+    }
+}
+
 impl Display for AppOrProxyId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.value())

--- a/shared/src/config.rs
+++ b/shared/src/config.rs
@@ -34,7 +34,8 @@ pub static CONFIG_SHARED: config_shared::Config = {
     load()
 };
 
-pub(crate) static CONFIG_SHARED_CRYPTO: OnceCell<ConfigCrypto> = OnceCell::new();
+// TODO: make this not mut by passing around ConfigCrypto before setting it
+pub(crate) static mut CONFIG_SHARED_CRYPTO: OnceCell<ConfigCrypto> = OnceCell::new();
 
 pub fn prepare_env() {
     for var in ["http_proxy", "https_proxy", "all_proxy", "no_proxy"] {

--- a/shared/src/config.rs
+++ b/shared/src/config.rs
@@ -34,7 +34,6 @@ pub static CONFIG_SHARED: config_shared::Config = {
     load()
 };
 
-// TODO: make this not mut by passing around ConfigCrypto before setting it
 pub(crate) static CONFIG_SHARED_CRYPTO: OnceCell<ConfigCrypto> = OnceCell::new();
 
 pub fn prepare_env() {

--- a/shared/src/config.rs
+++ b/shared/src/config.rs
@@ -35,7 +35,7 @@ pub static CONFIG_SHARED: config_shared::Config = {
 };
 
 // TODO: make this not mut by passing around ConfigCrypto before setting it
-pub(crate) static mut CONFIG_SHARED_CRYPTO: OnceCell<ConfigCrypto> = OnceCell::new();
+pub(crate) static CONFIG_SHARED_CRYPTO: OnceCell<ConfigCrypto> = OnceCell::new();
 
 pub fn prepare_env() {
     for var in ["http_proxy", "https_proxy", "all_proxy", "no_proxy"] {

--- a/shared/src/config_shared.rs
+++ b/shared/src/config_shared.rs
@@ -53,10 +53,11 @@ pub struct Config {
     pub tls_ca_certificates: Vec<X509>
 }
 
+#[derive(Debug)]
 pub struct ConfigCrypto {
     pub privkey_rs256: RS256KeyPair,
     pub privkey_rsa: RsaPrivateKey,
-    pub public: CryptoPublicPortion
+    pub public: Option<CryptoPublicPortion>
 }
 
 impl crate::config::Config for Config {
@@ -88,25 +89,33 @@ fn get_enrollment_msg(proxy_id: &Option<String>) -> String {
     )
 }
 
-pub async fn init_crypto_for_proxy() -> Result<(String, String), SamplyBeamError>{
+pub async fn init_public_crypto_for_proxy() -> Result<(String, String), SamplyBeamError>{
     let cli_args = CliArgs::parse();
-    let crypto = load_crypto_for_proxy(&cli_args).await?;
-    let cert_info = crypto::ProxyCertInfo::try_from(&crypto.public.cert)?;
-    if CONFIG_SHARED_CRYPTO.set(crypto).is_err() {
-        panic!("Tried to initialize crypto twice (init_crypto())");
-    }
+    load_public_crypto_for_proxy(&cli_args).await?;
+    let cert_info = &CONFIG_SHARED_CRYPTO.get().expect("Should be set by load_private_crypto_for_proxy").public.as_ref().expect("Set by load_public_crypto_for_proxy").cert;
+    let cert_info = crypto::ProxyCertInfo::try_from(cert_info)?;
     Ok((cert_info.serial, cert_info.common_name))
 }
 
-async fn load_crypto_for_proxy(cli_args: &CliArgs) -> Result<ConfigCrypto, SamplyBeamError> {
+pub fn load_private_crypto_for_proxy() -> Result<(), SamplyBeamError> {
+    let cli_args = CliArgs::parse();
     let privkey_pem = read_to_string(&cli_args.privkey_file)
         .map_err(|e| SamplyBeamError::ConfigurationFailed(format!("Unable to load private key from file {}: {}\n{}", cli_args.privkey_file.to_string_lossy(), e, get_enrollment_msg(&cli_args.proxy_id))))?
         .trim().to_string();
     let privkey_rsa = RsaPrivateKey::from_pkcs1_pem(&privkey_pem)
         .or_else(|_| RsaPrivateKey::from_pkcs8_pem(&privkey_pem))
         .map_err(|e| SamplyBeamError::ConfigurationFailed(format!("Unable to interpret private key PEM as PKCS#1 or PKCS#8: {}", e)))?;
-    let mut privkey_rs256 = RS256KeyPair::from_pem(&privkey_pem)
+    let privkey_rs256 = RS256KeyPair::from_pem(&privkey_pem)
         .map_err(|e| SamplyBeamError::ConfigurationFailed(format!("Unable to interpret private key PEM as PKCS#1 or PKCS#8: {}", e)))?;
+    CONFIG_SHARED_CRYPTO.set(ConfigCrypto {
+        privkey_rs256,
+        privkey_rsa,
+        public: None,
+    }).expect("Private crypto should be set first to load certificates from broker");
+    Ok(())
+}
+
+async fn load_public_crypto_for_proxy(cli_args: &CliArgs) -> Result<(), SamplyBeamError> {
     let proxy_id = cli_args.proxy_id.as_ref()
         .expect("load_crypto() has been called without setting a Proxy ID (maybe in broker?). This should not happen.");
     let proxy_id = ProxyId::new(proxy_id)?;
@@ -116,15 +125,12 @@ async fn load_crypto_for_proxy(cli_args: &CliArgs) -> Result<ConfigCrypto, Sampl
             r.map_err(|e| debug!("Unable to parse Certificate: {e}"))
             .ok())
         .collect();
-    let public = crypto::get_best_own_certificate(publics, &privkey_rsa).ok_or(SamplyBeamError::SignEncryptError("Unable to choose valid, newest certificate for this proxy".into()))?;
+    let mut config = CONFIG_SHARED_CRYPTO.get_mut().expect("Should have been set by load_private_crypto_for_proxy");
+    let public = crypto::get_best_own_certificate(publics, &config.privkey_rsa).ok_or(SamplyBeamError::SignEncryptError("Unable to choose valid, newest certificate for this proxy".into()))?;
     let serial = asn_str_to_vault_str(public.cert.serial_number())?;
-    privkey_rs256 = privkey_rs256.with_key_id(&serial);
-    let config = ConfigCrypto {
-        privkey_rs256,
-        privkey_rsa,
-        public,
-    };
-    Ok(config)
+    config.privkey_rs256 = config.privkey_rs256.with_key_id(&serial);
+    config.public = Some(public);
+    Ok(())
 }
 
 fn asn_str_to_vault_str(asn: &Asn1IntegerRef) -> Result<String,SamplyBeamError> {

--- a/shared/src/crypto.rs
+++ b/shared/src/crypto.rs
@@ -551,6 +551,11 @@ pub fn is_cert_from_privkey(cert: &X509, key: &RsaPrivateKey) -> Result<bool,Err
     return Ok(is_equal);
 }
 
+pub fn get_newest_cert(certs: &mut Vec<CryptoPublicPortion>) -> Option<CryptoPublicPortion> {
+    certs.sort_by(|a, b| a.cert.not_before().compare(b.cert.not_before()).expect("Unable to select newest certificate")); // sort by newest
+    certs.pop()
+}
+
 /// Selecs the best fitting certificate from a vector of certs according to:
 /// 1) Does it match the private key?
 /// 2) Is the current date in the valid date range?
@@ -562,8 +567,7 @@ pub(crate) fn get_best_own_certificate(publics: impl Into<Vec<CryptoPublicPortio
     debug!("get_best_certificate(): {} certificates match our private key.", publics.len());
     publics.retain(|c| x509_date_valid(&c.cert).unwrap_or(false)); // retain certs with valid dates
     debug!("get_best_certificate(): After sorting, {} certificates remaining.", publics.len());
-    publics.sort_by(|a,b| a.cert.not_before().compare(b.cert.not_before()).expect("Unable to select newest certificate").reverse()); // sort by newest
-    publics.first().cloned() // If empty vec --> return None
+    get_newest_cert(&mut publics)
 }
 
 /// Selecs the best fitting certificate from a vector of certs according to:
@@ -572,8 +576,7 @@ pub(crate) fn get_best_own_certificate(publics: impl Into<Vec<CryptoPublicPortio
 pub fn get_best_other_certificate(publics: &Vec<CryptoPublicPortion>) -> Option<CryptoPublicPortion> {
     let mut publics = publics.to_owned();
     publics.retain(|c| x509_date_valid(&c.cert).unwrap_or(false)); // retain certs with valid dates
-    publics.sort_by(|a,b| a.cert.not_before().compare(b.cert.not_before()).expect("Unable to select newest certificate").reverse()); // sort by newest
-    publics.first().cloned() // If empty vec --> return None
+    get_newest_cert(&mut publics)
 }
 
 pub async fn get_proxy_public_keys(receivers: impl IntoIterator<Item = &AppOrProxyId>) -> Result<Vec<RsaPublicKey>,SamplyBeamError> {

--- a/shared/src/crypto_jwt.rs
+++ b/shared/src/crypto_jwt.rs
@@ -88,8 +88,7 @@ pub async fn extract_jwt(token: &str) -> Result<(crypto::CryptoPublicPortion, RS
             .flatten()
             .collect::<Vec<_>>();
         // Get newest Certificate
-        certs.sort_by(|a, b| a.cert.not_before().compare(b.cert.not_before()).expect("Unable to select newest certificate").reverse()); // sort by newest
-        certs.into_iter().nth(0).ok_or(SamplyBeamError::CertificateError(CertificateInvalidReason::NoCommonName))?
+        crypto::get_newest_cert(&mut certs).ok_or(SamplyBeamError::CertificateError(CertificateInvalidReason::NoCommonName))?
     };
     let pubkey = RS256PublicKey::from_pem(&public.pubkey)
         .map_err(|e| {

--- a/shared/src/crypto_jwt.rs
+++ b/shared/src/crypto_jwt.rs
@@ -76,7 +76,8 @@ pub async fn extract_jwt(token: &str) -> Result<(crypto::CryptoPublicPortion, RS
             .ok_or_else(|| SamplyBeamError::VaultOtherError(format!("Unable to retrieve matching certificate for serial \"{}\"", serial)))?
             .map_err(|e| SamplyBeamError::CertificateError(e))?
     } else {
-        // if it does not have a serial in the metadata try to get it by readying the from in the body
+        // if it does not have a serial in the metadata try to get it by reading the from field in the body
+        // this happens, e.g. during proxy initialization before a certificate (serial) is received
         let data = token.splitn(3, ".").nth(1).ok_or(SamplyBeamError::RequestValidationFailed("Invalid JWT in header".to_string()))?;
         let data = base64::decode_block(data).map_err(|_| SamplyBeamError::RequestValidationFailed("Invalid JWT in header".to_string()))?;
         let json = serde_json::from_slice::<JWTClaims<HeaderClaim>>(&data).map_err(|_| SamplyBeamError::RequestValidationFailed("Invalid JWT body in header".to_string()))?;

--- a/shared/src/crypto_jwt.rs
+++ b/shared/src/crypto_jwt.rs
@@ -1,7 +1,7 @@
 use axum::{async_trait, extract::FromRequest, body::{HttpBody}, BoxError, http::StatusCode};
 use http::{Request, request::Parts};
 use hyper::{header::{self, HeaderName}, Method, Uri, HeaderMap};
-use jwt_simple::prelude::{Token, RS256PublicKey, RSAPublicKeyLike, RS256KeyPair, Claims, Duration, RSAKeyPairLike, KeyMetadata, Base64, VerificationOptions};
+use jwt_simple::{prelude::{Token, RS256PublicKey, RSAPublicKeyLike, RS256KeyPair, Claims, Duration, RSAKeyPairLike, KeyMetadata, Base64, VerificationOptions}, claims::JWTClaims};
 use openssl::base64;
 use serde::{Serialize, de::DeserializeOwned, Deserialize};
 use serde_json::Value;
@@ -94,7 +94,7 @@ pub async fn extract_jwt(token: &str) -> Result<(crypto::CryptoPublicPortion, RS
         // if it does not have a serial in the metadata try to get it by readying the from in the body
         let data = token.splitn(3, ".").nth(1).ok_or(SamplyBeamError::RequestValidationFailed("Invalid JWT in header".to_string()))?;
         let data = base64::decode_block(data).map_err(|_| SamplyBeamError::RequestValidationFailed("Invalid JWT in header".to_string()))?;
-        let json = serde_json::from_slice::<jwt_simple::claims::JWTClaims<HeaderClaim>>(&data).map_err(|_| SamplyBeamError::RequestValidationFailed("Invalid JWT body in header".to_string()))?;
+        let json = serde_json::from_slice::<JWTClaims<HeaderClaim>>(&data).map_err(|_| SamplyBeamError::RequestValidationFailed("Invalid JWT body in header".to_string()))?;
         let proxy_id: ProxyId = json.custom.from.get_proxy_id();
         let mut certs = crypto::get_all_certs_and_clients_by_cname_as_pemstr(&proxy_id)
             .await

--- a/shared/src/middleware.rs
+++ b/shared/src/middleware.rs
@@ -1,24 +1,70 @@
 use std::net::{IpAddr, SocketAddr};
 
 use axum::{middleware::{self, Next}, response::{Response, IntoResponse}, body::HttpBody, extract::ConnectInfo};
-use http::{Request, StatusCode, header::{self, HeaderName}, HeaderValue};
+use http::{Request, StatusCode, header::{self, HeaderName}, HeaderValue, Method, Uri};
 use hyper::Body;
 use tracing::{info, warn, span, Level, instrument};
 
+use crate::beam_id::AppOrProxyId;
+
 const X_FORWARDED_FOR: HeaderName = HeaderName::from_static("x-forwarded-for");
 
-pub async fn log(ConnectInfo(info): ConnectInfo<SocketAddr>, req: Request<Body>, next: Next<Body>) -> Response {
+pub struct LoggingInfo {
+    // Known from the start
+    method: Method,
+    uri: Uri,
+    ip: IpAddr,
+
+    // Added by SignedMsg extractor
+    from_proxy: Option<AppOrProxyId>,
+
+    // Added after handlers
+    status_code: Option<StatusCode>
+}
+
+impl LoggingInfo {
+    fn new(method: Method, uri: Uri, ip: IpAddr) -> Self {
+        Self { method, uri, ip, from_proxy: None, status_code: None }
+    }
+
+    fn set_status_code(&mut self, status: StatusCode) {
+        self.status_code = Some(status);
+    }
+
+    pub fn set_proxy_name(&mut self, proxy: AppOrProxyId) {
+        self.from_proxy = Some(proxy);
+    }
+
+    fn get_log(&self) -> String {
+        let from = self.from_proxy.as_ref().map(|id| id.to_string()).unwrap_or(self.ip.to_string());
+        format!("{} {} {} {}",
+            from,
+            self.status_code
+                .expect("Did not set Statuscode before loggin"),
+            self.method,
+            self.uri
+        )
+    }
+}
+
+pub async fn log(ConnectInfo(info): ConnectInfo<SocketAddr>, mut req: Request<Body>, next: Next<Body>) -> Response {
     let method = req.method().clone();
     let uri = req.uri().clone();
     let ip = get_ip(&req, &info);
 
-    let resp = next.run(req).await;
+    let mut logging_info = LoggingInfo::new(method, uri, ip);
+    // Somehow give this a mut ref so I can use it after
+    req.extensions_mut().insert(&mut logging_info);
 
-    let line = format!("{} {} {} {}",
-        ip,
-        resp.status().as_u16(),
-        method,
-        uri);
+    let mut resp = next.run(req).await;
+
+    let status = resp.status();
+
+    let loging_info = resp.extensions_mut().get_mut::<LoggingInfo>().expect("Did someone remove it from extensions?");
+    loging_info.set_status_code(status);
+
+
+    let line = loging_info.get_log();
     if resp.status().is_success() {
         info!(target: "in", "{}", line);
     } else {

--- a/shared/src/middleware.rs
+++ b/shared/src/middleware.rs
@@ -48,13 +48,15 @@ impl LoggingInfo {
     }
 }
 
+pub type LoggingExtension = Arc<Mutex<LoggingInfo>>;
+
 pub async fn log(ConnectInfo(info): ConnectInfo<SocketAddr>, mut req: Request<Body>, next: Next<Body>) -> Response {
     let method = req.method().clone();
     let uri = req.uri().clone();
     let ip = get_ip(&req, &info);
 
+    // TODO: find a smarter way to do this maybe oneshot channel or something completly diffrent
     let logging_info = Arc::new(Mutex::new(LoggingInfo::new(method, uri, ip)));
-    // Somehow give this a mut ref so I can use it after
     req.extensions_mut().insert( logging_info.clone());
 
     let resp = next.run(req).await;


### PR DESCRIPTION
Proxy config is now initialized in 2 Steps:
1. Read private keys
2. Get public info from broker and set global `CONFIG_SHARED_CRYPTO`

Added type alias for `Authorized` for `MsgSigned<MsgEmpty>`

The local `test noci` ist not passing for me due to a task beeing removed too early, but somehow CI here is passing.
Update: I have the same issue on origin develop
