### PR TITLE
Refactor messages and fix msg verification

### DIFF
--- a/shared/src/beam_id.rs
+++ b/shared/src/beam_id.rs
@@ -194,6 +194,15 @@ pub enum AppOrProxyId {
     ProxyId(ProxyId),
 }
 
+impl AppOrProxyId {
+    pub fn get_proxy_id(&self) -> ProxyId {
+        match self {
+            AppOrProxyId::AppId(app) => app.proxy_id(),
+            AppOrProxyId::ProxyId(proxy) => proxy.clone() 
+        }
+    }
+}
+
 impl Display for AppOrProxyId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.value())

--- a/shared/src/crypto.rs
+++ b/shared/src/crypto.rs
@@ -585,8 +585,8 @@ pub async fn get_proxy_public_keys(receivers: impl IntoIterator<Item = &AppOrPro
         }).collect();
     let receivers_crypto_bundle = crypto::get_newest_certs_for_cnames_as_pemstr(proxy_receivers.iter()).await;
     let receivers_keys = match receivers_crypto_bundle {
-        Some(vec) => Ok(vec.iter().map(|crypt_publ| rsa::RsaPublicKey::from_public_key_pem(&crypt_publ.pubkey).expect("Cannot collect recipients' public keys")).collect::<Vec<rsa::RsaPublicKey>>()), // TODO Expect
-        None => Err(SamplyBeamError::SignEncryptError("Cannot gather encryption keys.".into()))
-    }?;
+        Some(vec) => vec.iter().map(|crypt_publ| rsa::RsaPublicKey::from_public_key_pem(&crypt_publ.pubkey).expect("Cannot collect recipients' public keys")).collect::<Vec<rsa::RsaPublicKey>>(), // TODO Expect
+        None => Vec::new()
+    };
     Ok(receivers_keys)
 }

--- a/shared/src/crypto.rs
+++ b/shared/src/crypto.rs
@@ -373,6 +373,17 @@ pub async fn get_all_certs_and_clients_by_cname_as_pemstr(cname: &ProxyId) -> Ve
         .collect()
 }
 
+pub async fn get_best_cert_for_proxy(proxy_id: &ProxyId) -> Result<CryptoPublicPortion, CertificateInvalidReason>  {
+    let mut certs = crypto::get_all_certs_and_clients_by_cname_as_pemstr(&proxy_id)
+        .await
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    // Get newest Certificate
+    certs.sort_by(|a, b| a.cert.not_before().compare(b.cert.not_before()).expect("Unable to select newest certificate").reverse()); // sort by newest
+    certs.into_iter().nth(0).ok_or(CertificateInvalidReason::NoCommonName)
+}
+
 pub async fn get_cert_and_client_by_serial_as_pemstr(serial: &str) -> Option<Result<CryptoPublicPortion,CertificateInvalidReason>> {
     match get_cert_by_serial(serial).await {
         None => None,

--- a/shared/src/crypto_jwt.rs
+++ b/shared/src/crypto_jwt.rs
@@ -7,7 +7,7 @@ use serde::{Serialize, de::DeserializeOwned, Deserialize};
 use serde_json::Value;
 use static_init::dynamic;
 use tracing::{debug, error, warn};
-use crate::{BeamId, errors::SamplyBeamError, crypto, Msg, MsgSigned, MsgEmpty, MsgId, MsgWithBody, config, beam_id::{ProxyId, AppOrProxyId}};
+use crate::{BeamId, errors::SamplyBeamError, crypto, Msg, MsgSigned, MsgEmpty, MsgId, config, beam_id::{ProxyId, AppOrProxyId}};
 
 const ERR_SIG: (StatusCode, &str) = (StatusCode::UNAUTHORIZED, "Signature could not be verified");
 // const ERR_CERT: (StatusCode, &str) = (StatusCode::BAD_REQUEST, "Unable to retrieve matching certificate.");
@@ -23,7 +23,7 @@ where
     B::Data: Send,
     B::Error: Into<BoxError>,
     B: HttpBody + 'static,
-    T: Serialize + DeserializeOwned + MsgWithBody
+    T: Serialize + DeserializeOwned + Msg
 {
     type Rejection = (StatusCode, &'static str);
 
@@ -34,32 +34,13 @@ where
             warn!("Unable to parse token_without_extended_signature as UTF-8: {}", e);
             ERR_SIG
         })?;
-        verify_with_extended_header(&parts, Some(token_without_extended_signature)).await
+        verify_with_extended_header(&parts, token_without_extended_signature).await
     }
 }
 
-#[async_trait]
-impl<S,B> FromRequest<S,B> for MsgSigned<MsgEmpty>
-where
-    // these trait bounds are copied from `impl FromRequest for axum::Json`
-    // T: DeserializeOwned,
-    // B: axum::body::HttpBody + Send,
-    // B::Data: Send,
-    // B::Error: Into<BoxError>,
-    // T: Serialize + DeserializeOwned + Msg
-    S: Send + Sync,
-    B: Send + 'static,
-{
-    type Rejection = (StatusCode, &'static str);
-
-    async fn from_request(req: Request<B>, _state: &S) -> Result<Self, Self::Rejection> {
-        let (parts, _) = req.into_parts();
-        verify_with_extended_header(&parts, None).await
-    }
-}
 
 #[tracing::instrument]
-pub async fn extract_jwt(token: &str) -> Result<(crypto::CryptoPublicPortion, RS256PublicKey, jwt_simple::prelude::JWTClaims<Value>), SamplyBeamError> {
+pub async fn extract_jwt<T: DeserializeOwned + Serialize>(token: &str) -> Result<(crypto::CryptoPublicPortion, RS256PublicKey, jwt_simple::prelude::JWTClaims<T>), SamplyBeamError> {
     // TODO: Make static/const
     let options = VerificationOptions {
         accept_future: true,
@@ -78,13 +59,17 @@ pub async fn extract_jwt(token: &str) -> Result<(crypto::CryptoPublicPortion, RS
         .map_err(|e| {
             SamplyBeamError::SignEncryptError(format!("Unable to initialize public key: {}", e))
         })?;
-    let content = pubkey.verify_token::<Value>(token, Some(options))
+    let content = pubkey.verify_token::<T>(token, Some(options))
         .map_err(|e| SamplyBeamError::RequestValidationFailed(format!("Unable to verify token and extract claims from JWT: {}", e)))?;
     Ok((public, pubkey, content))
 }
 
 #[tracing::instrument]
-async fn verify_with_extended_header<M: Msg + DeserializeOwned>(req: &Parts, token_without_extended_signature: Option<&str>) -> Result<MsgSigned<M>,(StatusCode, &'static str)> {
+/// This verifys a Msg from sent to the Broker
+/// The Message is encoded in the JWT Claims of the body which is a JWT.
+/// There is never really a [`MsgSigned`] involved in Deserializing the message as the signature is just copyed from the body JWT.
+/// The token is verified by a key derived from the kid of the JWT in the Header which should also match the kid of the body JWT.
+async fn verify_with_extended_header<M: Msg + DeserializeOwned>(req: &Parts, token_without_extended_signature: &str) -> Result<MsgSigned<M>,(StatusCode, &'static str)> {
     let token_with_extended_signature = std::str::from_utf8(req.headers.get(header::AUTHORIZATION).ok_or_else(|| {
         warn!("Missing Authorization header (in verify_with_extended_header)");
         ERR_SIG
@@ -96,8 +81,8 @@ async fn verify_with_extended_header<M: Msg + DeserializeOwned>(req: &Parts, tok
             })?;
     let token_with_extended_signature = token_with_extended_signature.trim_start_matches("SamplyJWT ");
     
-    let (proxy_public_info, pubkey, mut header_claims) 
-        = extract_jwt(token_with_extended_signature).await
+    let (proxy_public_info, pubkey, header_claims) 
+        = extract_jwt::<HeaderClaim>(token_with_extended_signature).await
         .map_err(|e| {
             warn!("Unable to extract header JWT: {}. The full JWT was: {}. The header was: {:?}", e, token_with_extended_signature, req);
             ERR_SIG
@@ -105,34 +90,9 @@ async fn verify_with_extended_header<M: Msg + DeserializeOwned>(req: &Parts, tok
     
     // Check extra digest
 
-    let custom = header_claims.custom.as_object_mut();
-    if custom.is_none() {
-        warn!("Received a request with empty JWT custom claims");
-        return Err(ERR_SIG);
-    }
-    let custom = custom.unwrap();
-    let digest_claimed = custom.get("s");
-
-    if digest_claimed.is_none() {
-        warn!("Received a request but had an empty header signature");
-        return Err(ERR_SIG);
-    }
-    let digest_claimed = digest_claimed.unwrap();
-    if ! digest_claimed.is_string() {
-        warn!("Received a request but header signature was not a valid string");
-        return Err(ERR_SIG);
-    }
-    let digest_claimed = digest_claimed.as_str().unwrap();
-    let sender_claimed = custom.get("f");
-    if sender_claimed.is_none() {
-        warn!("Received a request but had an empty header signature");
-        return Err(ERR_SIG);
-    }
-    let sender_claimed = sender_claimed.unwrap().to_owned();
-    let sender_claimed = serde_json::from_value::<AppOrProxyId>(sender_claimed).map_err(|e| {
-        warn!("Recieved a request with an invalid SenderID in header token: {}", e);
-        ERR_SIG
-    })?;
+    let custom = header_claims.custom;
+    let digest_claimed = custom.sig;
+    let sender_claimed = custom.from;
 
     // TODO: Make static/const
     let options = VerificationOptions {
@@ -141,67 +101,45 @@ async fn verify_with_extended_header<M: Msg + DeserializeOwned>(req: &Parts, tok
         ..Default::default()
     };
 
-    let (custom_without, sig) = if let Some(token_without_extended_signature) = token_without_extended_signature {
-        
-        // Check if short token matches the long token
-        let content_without = pubkey.verify_token::<Value>(token_without_extended_signature, Some(options))
-            .map_err(|e| {
-                warn!("Unable to verify short token {}: {}", token_without_extended_signature, e);
-                ERR_SIG
-            })?;
-        let custom_without = content_without.custom.as_object();
-        if custom_without.is_none() {
-            warn!("Upon message verification, encountered an empty custom_without.");
-            return Err(ERR_SIG);
-        }
-        let custom_without = custom_without.unwrap();
-        let custom_without = serde_json::from_value::<M>(Value::Object(custom_without.clone()))
-            .map_err(|e| {
-                warn!("Unable to unpack custom_without to JSON value, returning ERR_BODY: {}", e);
-                ERR_BODY
-        })?;
-        let sig = if let Some(sig) = token_without_extended_signature.rsplit_once('.') {sig.1} else {warn!("Cannot split signature from body token"); return Err(ERR_SIG);};
-        (custom_without, sig)
-    } else {
-        let msg_empty = MsgEmpty {
-            from: sender_claimed.clone(),
-        };
-        let serialized = serde_json::to_string(&msg_empty).unwrap(); // known input
-        (
-             serde_json::from_str::<M>(&serialized).unwrap(), // known input
-             ""
-        )
-    };
-    let sender_actual = custom_without.get_from();
-    if !(sig.is_empty() && token_without_extended_signature.is_none()) { // Not a MsgEmpty
+    // Check if short token matches the long token
+    let msg = pubkey.verify_token::<M>(token_without_extended_signature, Some(options))
+        .map_err(|e| {
+            warn!("Unable to verify short token {}: {}", token_without_extended_signature, e);
+            ERR_SIG
+        })?.custom;
 
-        // Check if header claims is matching the body token
-        let digest_actual = make_extra_fields_digest(&req.method, &req.uri, &req.headers, &sig, &sender_actual)
+    let Some((_, sig)) = token_without_extended_signature.rsplit_once('.') else {
+        warn!("Cannot split signature from body token");
+        return Err(ERR_SIG);
+    };
+    let sender_actual = msg.get_from();
+
+    // Check if header claims is matching the body token
+    let digest_actual = make_extra_fields_digest(&req.method, &req.uri, &req.headers, &sig, &sender_actual)
         .map_err(|e| {
             warn!("Got error in make_extra_fields_digest: {}", e);
             ERR_SIG
         })?.sig;
 
-        if digest_actual != digest_claimed {
-            warn!("Digests did not match: expected {}, received {}", digest_claimed, digest_actual);
-            return Err(ERR_SIG);
-        }
+    if digest_actual != digest_claimed {
+        warn!("Digests did not match: expected {}, received {}", digest_claimed, digest_actual);
+        return Err(ERR_SIG);
+    }
 
-        if sender_actual.to_owned() != sender_claimed {
-            warn!("Sender did not match: expected {}, received {}", sender_claimed, sender_actual);
-            return Err(ERR_SIG);
-        }
+    if sender_actual.to_owned() != sender_claimed {
+        warn!("Sender did not match: expected {}, received {}", sender_claimed, sender_actual);
+        return Err(ERR_SIG);
     }
 
     // Check if Messages' "from" attribute can be signed by the proxy
-    if ! custom_without.get_from().can_be_signed_by(&proxy_public_info.beam_id) {
+    if !msg.get_from().can_be_signed_by(&proxy_public_info.beam_id) {
         warn!("Received messages' \"from\" attribute which should not have been signed by the proxy.");
         return Err(ERR_FROM);
     }
     // TODO: Check if Date header makes sense (replay attacks)
 
     let msg_signed = MsgSigned{
-        msg: custom_without,
+        msg,
         sig: sig.to_string()
     };
 

--- a/shared/src/crypto_jwt.rs
+++ b/shared/src/crypto_jwt.rs
@@ -135,7 +135,7 @@ async fn verify_with_extended_header<M: Msg + DeserializeOwned>(req: &Parts, tok
 
     let msg_signed = MsgSigned{
         msg,
-        sig: sig.to_string()
+        jwt: token_without_extended_signature.to_string()
     };
 
     Ok(msg_signed)

--- a/shared/src/errors.rs
+++ b/shared/src/errors.rs
@@ -17,7 +17,7 @@ pub enum SamplyBeamError {
     #[error("Invalid Client ID: {0}")]
     InvalidClientIdString(String),
     #[error("Unable to parse JSON: {0}")]
-    JsonParseError(&'static str),
+    JsonParseError(String),
     #[error("Decryption error: {0}")]
     DecryptError(&'static str),
     #[error("Signing / encryption failed: {0}")]

--- a/shared/src/examples.rs
+++ b/shared/src/examples.rs
@@ -47,7 +47,7 @@ pub fn generate_example_tasks(broker: Option<BrokerId>, proxy: Option<ProxyId>) 
     let task_for_apps_1_2 = MsgTaskRequest::new(
         app1.clone().into(),
         vec![app1.clone().into(), app2.clone().into()],
-        "My important task".to_string(),
+        "My important task".into(),
         FailureStrategy::Retry { backoff_millisecs: 1000, max_tries: 5 },
         json!(["The", "Broker", "can", "read", "and", "filter", "this"])
     );
@@ -57,7 +57,7 @@ pub fn generate_example_tasks(broker: Option<BrokerId>, proxy: Option<ProxyId>) 
         to: vec![app1.clone().into()],
         task: task_for_apps_1_2.id,
         status: crate::WorkStatus::Succeeded,
-        body: Some("All done!".to_string()),
+        body: "All done!".into(),
         metadata: json!("A normal string works, too!")
     };
     let response_by_app2 = MsgTaskResult {
@@ -65,7 +65,7 @@ pub fn generate_example_tasks(broker: Option<BrokerId>, proxy: Option<ProxyId>) 
         to: vec![app1.into()],
         task: task_for_apps_1_2.id,
         status: crate::WorkStatus::PermFailed,
-        body: Some("Unable to complete".to_string()),
+        body: "Unable to complete".into(),
         metadata: json!({ "I": { "like": [ "results", "cake" ] } })
     };
     let mut tasks = Vec::new();

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -140,7 +140,8 @@ pub struct MsgSigned<M: Msg> {
 impl<M: Msg> MsgSigned<M> {
     pub async fn verify(&self) -> Result<(), SamplyBeamError> {
         // Signature valid?
-        let (proxy_public_info, _, content) = extract_jwt(&self.sig).await?;
+        // TODO: This needs to be rewritten
+        let (proxy_public_info, _, content) = extract_jwt::<Value>(&self.sig).await?;
 
         // Message content matches token?
         let val = serde_json::to_value(&self.msg)
@@ -398,9 +399,6 @@ pub trait Msg: Serialize {
     fn get_metadata(&self) -> &Value;
 }
 
-pub trait MsgWithBody: Msg {}
-impl<T: MsgState> MsgWithBody for MsgTaskRequest<T> {}
-impl<T: MsgState> MsgWithBody for MsgTaskResult<T> {}
 
 impl<M: Msg> Msg for MsgSigned<M> {
     fn get_from(&self) -> &AppOrProxyId {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -218,6 +218,28 @@ impl EncryptableMsg for PlainMessage {
     }
 }
 
+const MESSAGE_EMPTY_ENCRYPTION: &Encrypted = &Encrypted { encrypted: Vec::new(), encryption_keys: Vec::new() };
+
+impl DecryptableMsg for EncryptedMessage {
+    type Output = PlainMessage;
+
+    fn convert_self(self, body: String) -> Self::Output {
+        match self {
+            Self::MsgTaskRequest(m) => Self::Output::MsgTaskRequest(m.convert_self(body)),
+            Self::MsgTaskResult(m) => Self::Output::MsgTaskResult(m.convert_self(body)),
+            Self::MsgEmpty(m) => Self::Output::MsgEmpty(m)
+        }
+    }
+
+    fn get_encryption(&self) -> &Encrypted {
+        match self {
+            Self::MsgTaskRequest(m) => m.get_encryption(),
+            Self::MsgTaskResult(m) => m.get_encryption(),
+            Self::MsgEmpty(_) => MESSAGE_EMPTY_ENCRYPTION,
+        }
+    }
+}
+
 impl<T: MsgState> Msg for MessageType<T> {
     fn get_from(&self) -> &AppOrProxyId {
         use MessageType::*;


### PR DESCRIPTION
### Changes:
1. `MsgSigned` now only holds a full JWT when sent to the proxy as JSON.
2. `MsgSigned` now gets veryfied on the proxy.
3. `MsgTaskRequest` and `MsgTaskResult` are now generic over their encryption status (the encrypted versions of these types still exist as a type alias).
4. There is a new `MessageType` enum which is also generic over its encryption status. It is used to unify the Serialization of Messages.
5. A lot of small refactors.