### PR TITLE
Dont crash the server if there is no `Accept` header

### DIFF
--- a/proxy/src/serve_tasks.rs
+++ b/proxy/src/serve_tasks.rs
@@ -90,8 +90,10 @@ async fn handler_task(
     headers: HeaderMap,
     req: Request<Body>
 ) -> Result<Response, (StatusCode, String)> {
-    let found = &headers[header::ACCEPT]
-        .to_str().unwrap_or_default()
+    let found = &headers.get(header::ACCEPT)
+        .unwrap_or(&HeaderValue::from_static(""))
+        .to_str()
+        .unwrap_or_default()
         .split(',')
         .map(|part| part.trim())
         .find(|part| *part == "text/event-stream")


### PR DESCRIPTION
If the header is not set we will return json and not crash.