### PR TITLE
Stricter `MsgEmpty` parsing

### DIFF
--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -155,6 +155,7 @@ impl<M: Msg + DeserializeOwned> MsgSigned<M> {
 pub static EMPTY_VEC_APPORPROXYID: Vec<AppOrProxyId> = Vec::new();
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct MsgEmpty {
     pub from: AppOrProxyId,
 }


### PR DESCRIPTION
I tried to add `deny_unknown_fields` to `MessageType` but that does not seem to work.

We might want to consider adding this attribute to `MsgTaskRequest` and `MsgTaskResult` as well?