### PR TITLE
Fix readme updates

### DIFF
--- a/.github/workflows/dockerhub_readme.yml
+++ b/.github/workflows/dockerhub_readme.yml
@@ -24,4 +24,4 @@ jobs:
           repository: ${{ github.repository }}-${{ matrix.component }}
           readme: "./README.md"
           replace_pattern: "](./"
-          replace_with: "](${{ github.server_url }}/${{ github.repository }}/raw/${{ github.ref_name }}/"
+          replace_with: "](https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/"


### PR DESCRIPTION
I am not sure if this will work as this workflow only runs on pushes to main, but the old generated url seemed to be deprecated as mentioned by @torbrenner. I replaced it with this url https://raw.githubusercontent.com/{owner}/{repo}/{branch}/README.md which should work if I got the string replacement right.