### PR TITLE
Invalidate certs when expired

### DIFF
--- a/proxy/src/crypto.rs
+++ b/proxy/src/crypto.rs
@@ -101,7 +101,8 @@ impl GetCerts for GetCertsFromBroker {
     }
 
     async fn on_cert_expired(&self, expired_cert: shared::openssl::x509::X509) {
-        let own_cert = &self.crypto_conf
+        // We can't use our own `ConfigCrypto` here as it is only an intermidate config for getting initial certs from the broker
+        let own_cert = shared::crypto::get_own_crypto_material()
             .public
             .as_ref()
             .expect("Fatal error: Unable to read our own certificate.");

--- a/proxy/src/crypto.rs
+++ b/proxy/src/crypto.rs
@@ -96,13 +96,13 @@ impl GetCerts for GetCertsFromBroker {
     }
 
     async fn im_certificate_as_pem(&self) -> Result<String, SamplyBeamError> {
-        debug!("Retrieving im ca certificate ...");
+        debug!("Retrieving intermediate CA certificate ...");
         self.query("/v1/pki/certs/im-ca").await
     }
 
-    async fn on_cert_expired(&self, _cert: shared::openssl::x509::X509) {
+    async fn on_own_cert_expired(&self, _cert: shared::openssl::x509::X509) {
         // TODO Tobias will find a smart solution ;)
-        error!("Cert expired restarting");
+        error!("Own cert has just expired -- exiting.");
         std::process::exit(13);
     }
 }

--- a/proxy/src/crypto.rs
+++ b/proxy/src/crypto.rs
@@ -12,7 +12,7 @@ use shared::{
     http_client::SamplyHttpClient,
     EncryptedMessage, MsgEmpty,
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, info, warn, error};
 
 use crate::serve_tasks::sign_request;
 
@@ -98,6 +98,12 @@ impl GetCerts for GetCertsFromBroker {
     async fn im_certificate_as_pem(&self) -> Result<String, SamplyBeamError> {
         debug!("Retrieving im ca certificate ...");
         self.query("/v1/pki/certs/im-ca").await
+    }
+
+    async fn on_cert_expired(&self, _cert: shared::openssl::x509::X509) {
+        // TODO Tobias will find a smart solution ;)
+        error!("Cert expired restarting");
+        std::process::exit(13);
     }
 }
 

--- a/proxy/src/crypto.rs
+++ b/proxy/src/crypto.rs
@@ -100,10 +100,17 @@ impl GetCerts for GetCertsFromBroker {
         self.query("/v1/pki/certs/im-ca").await
     }
 
-    async fn on_own_cert_expired(&self, _cert: shared::openssl::x509::X509) {
-        // TODO Tobias will find a smart solution ;)
-        error!("Own cert has just expired -- exiting.");
-        std::process::exit(13);
+    async fn on_cert_expired(&self, expired_cert: shared::openssl::x509::X509) {
+        let own_cert = &self.crypto_conf
+            .public
+            .as_ref()
+            .expect("Fatal error: Unable to read our own certificate.");
+        let own_cert = &own_cert.cert;
+        if expired_cert.serial_number() == own_cert.serial_number() {
+            // TODO Tobias will find a smart solution ;)
+            error!("Our own cert has just expired -- exiting.");
+            std::process::exit(13);
+        }
     }
 }
 

--- a/proxy/src/serve_tasks.rs
+++ b/proxy/src/serve_tasks.rs
@@ -442,7 +442,7 @@ async fn validate_and_decrypt(json: Value) -> Result<Value, SamplyBeamError> {
 fn decrypt_msg<M: DecryptableMsg>(msg: M) -> Result<M::Output, SamplyBeamError> {
     msg.decrypt(
         &AppOrProxyId::ProxyId(CONFIG_PROXY.proxy_id.to_owned()),
-        crypto::get_own_privkey(),
+        &crypto::get_own_crypto_material().privkey_rsa,
     )
 }
 

--- a/shared/src/crypto.rs
+++ b/shared/src/crypto.rs
@@ -168,7 +168,6 @@ impl CertificateCache {
                         }
                     }
                 }
-            
             };
         } // Drop Read Locks
         if result.is_empty() {

--- a/shared/src/crypto.rs
+++ b/shared/src/crypto.rs
@@ -103,7 +103,7 @@ pub trait GetCerts: Sync + Send {
     async fn certificate_list(&self) -> Result<Vec<String>, SamplyBeamError>;
     async fn certificate_by_serial_as_pem(&self, serial: &str) -> Result<String, SamplyBeamError>;
     async fn im_certificate_as_pem(&self) -> Result<String, SamplyBeamError>;
-    async fn on_cert_expired(&self, _cert: X509) {}
+    async fn on_own_cert_expired(&self, _cert: X509) {}
 }
 
 impl CertificateCache {
@@ -468,7 +468,7 @@ pub(crate) static CERT_CACHE: Arc<RwLock<CertificateCache>> = {
                 };
                 *entry = CertificateCacheEntry::Invalid(CertificateInvalidReason::InvalidDate);
             }
-            CERT_GETTER.get().unwrap().on_cert_expired(old_cert).await;
+            CERT_GETTER.get().unwrap().on_own_cert_expired(old_cert).await;
         }
     });
     cc

--- a/shared/src/crypto.rs
+++ b/shared/src/crypto.rs
@@ -103,7 +103,7 @@ pub trait GetCerts: Sync + Send {
     async fn certificate_list(&self) -> Result<Vec<String>, SamplyBeamError>;
     async fn certificate_by_serial_as_pem(&self, serial: &str) -> Result<String, SamplyBeamError>;
     async fn im_certificate_as_pem(&self) -> Result<String, SamplyBeamError>;
-    async fn on_own_cert_expired(&self, _cert: X509) {}
+    async fn on_cert_expired(&self, _expired_cert: X509) {}
 }
 
 impl CertificateCache {
@@ -476,7 +476,7 @@ pub(crate) static CERT_CACHE: Arc<RwLock<CertificateCache>> = {
                 };
                 *entry = CertificateCacheEntry::Invalid(CertificateInvalidReason::InvalidDate);
             }
-            CERT_GETTER.get().unwrap().on_own_cert_expired(oldest_cert).await;
+            CERT_GETTER.get().unwrap().on_cert_expired(oldest_cert).await;
         }
     });
     cc
@@ -606,8 +606,8 @@ pub(crate) fn hash(data: &[u8]) -> Result<[u8; 32], SamplyBeamError> {
     Ok(digest)
 }
 
-pub fn get_own_privkey() -> &'static RsaPrivateKey {
-    &config::CONFIG_SHARED_CRYPTO.get().unwrap().privkey_rsa
+pub fn get_own_crypto_material() -> &'static ConfigCrypto {
+    config::CONFIG_SHARED_CRYPTO.get().unwrap()
 }
 /* Utility Functions */
 

--- a/shared/src/crypto_jwt.rs
+++ b/shared/src/crypto_jwt.rs
@@ -176,6 +176,12 @@ async fn verify_with_extended_header<M: Msg + DeserializeOwned>(
                 ERR_SIG
             })?;
 
+    req.extensions
+        .remove::<ProxyLogger>()
+        .expect("Should be set by middleware")
+        .send(header_claims.custom.from.clone())
+        .expect("Reciever still lives in middleware");
+
     // Check extra digest
 
     let custom = header_claims.custom;
@@ -241,12 +247,6 @@ async fn verify_with_extended_header<M: Msg + DeserializeOwned>(
         msg,
         jwt: token_without_extended_signature.to_string(),
     };
-    req.extensions
-        .remove::<ProxyLogger>()
-        .expect("Should be set by middleware")
-        .send(msg_signed.get_from().clone())
-        .expect("Reciever still lives in middleware");
-
     Ok(msg_signed)
 }
 

--- a/shared/src/crypto_jwt.rs
+++ b/shared/src/crypto_jwt.rs
@@ -180,7 +180,7 @@ async fn verify_with_extended_header<M: Msg + DeserializeOwned>(
         .remove::<ProxyLogger>()
         .expect("Should be set by middleware")
         .send(header_claims.custom.from.clone())
-        .expect("Reciever still lives in middleware");
+        .expect("Receiver still lives in middleware");
 
     // Check extra digest
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -60,6 +60,9 @@ pub mod examples;
 
 pub mod sse_event;
 
+// Reexports
+pub use openssl;
+
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MyUuid(Uuid);
 impl MyUuid {

--- a/shared/src/middleware.rs
+++ b/shared/src/middleware.rs
@@ -83,7 +83,7 @@ pub async fn log(
     let ip = get_ip(&req, &info);
 
     let mut info = LoggingInfo::new(method, uri, ip);
-    // This channel may or may not recieve an AppOrProxyId from verify_with_extended_header
+    // This channel may or may not receive an AppOrProxyId from verify_with_extended_header
     let (tx, mut rx) = oneshot::channel();
     req.extensions_mut().insert(tx);
 


### PR DESCRIPTION
This PR also contains a small improvement to logging which will now log `from` which app the request is even if the request could not be verified.