### PR TITLE
Differentiate connection errors in proxy

### DIFF
--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -19,6 +19,8 @@ mod serve;
 mod serve_health;
 mod serve_tasks;
 
+pub(crate) const PROXY_TIMEOUT: u64 = 120;
+
 #[tokio::main]
 pub async fn main() -> anyhow::Result<()> {
     shared::config::prepare_env();
@@ -28,7 +30,7 @@ pub async fn main() -> anyhow::Result<()> {
     let config = config::CONFIG_PROXY.clone();
     let client = http_client::build(
         &config::CONFIG_SHARED.tls_ca_certificates,
-        Some(Duration::from_secs(120)),
+        Some(Duration::from_secs(PROXY_TIMEOUT)),
         Some(Duration::from_secs(20)),
     )
     .map_err(SamplyBeamError::HttpProxyProblem)?;

--- a/proxy/src/serve_tasks.rs
+++ b/proxy/src/serve_tasks.rs
@@ -47,7 +47,7 @@ use shared::{
 use tokio::io::BufReader;
 use tracing::{debug, error, info, trace, warn};
 
-use crate::auth::AuthenticatedApp;
+use crate::{auth::AuthenticatedApp, PROXY_TIMEOUT};
 
 #[derive(Clone, FromRef)]
 struct TasksState {
@@ -111,8 +111,13 @@ async fn forward_request(
     let req = sign_request(encrypted_msg, parts, &config, None).await?;
     trace!("Requesting: {:?}", req);
     let resp = client.request(req).await.map_err(|e| {
-        warn!("Request to broker failed: {}", e.to_string());
-        (StatusCode::BAD_GATEWAY, "Upstream error; see server logs.")
+        if e.is_timeout() {
+            debug!("Request to broker timed out after set proxy timeout of {PROXY_TIMEOUT}s");
+            (StatusCode::GATEWAY_TIMEOUT, "Request to broker timed out ")
+        } else {
+            warn!("Request to broker failed: {}", e.to_string());
+            (StatusCode::BAD_GATEWAY, "Upstream error; see server logs.")
+        }
     })?;
     Ok(resp)
 }

--- a/shared/src/middleware.rs
+++ b/shared/src/middleware.rs
@@ -95,7 +95,8 @@ pub async fn log(
     }
 
     let line = info.get_log();
-    if resp.status().is_success() {
+    // If we get a gateway timeout we won't log it with log level warn as this happens regularly with the long polling api
+    if resp.status().is_success() || resp.status() == StatusCode::GATEWAY_TIMEOUT {
         info!(target: "in", "{}", line);
     } else {
         warn!(target: "in", "{}", line);


### PR DESCRIPTION
For clients that use long polling like `beam-connect` a request with a wait time of more than 2min (which is the default timeout set in the proxy client) the proxy would give a `502 Bad Gateway` if no tasks where found in that time. This also lead to warnings in the logs which let people to think there was something wrong with beam.

The proxy will now respond with a `504 Gateway Timeout` instead which may might break clients that used the 502 to check if the connection timed out. @enola-dkfz? So we might want to wait a bit before merging this.