### PR TITLE
Expire already expired task immediately

### DIFF
--- a/broker/src/expire.rs
+++ b/broker/src/expire.rs
@@ -42,11 +42,11 @@ pub(crate) async fn watch(
             Some(soonest) => match soonest.duration_since(SystemTime::now()) {
                 Ok(x) => x,
                 Err(expired_since) => {
-                    warn!(
+                    debug!(
                         "Tried to wait on a task that had in fact expired since {}.",
                         expired_since
                     );
-                    Duration::MAX
+                    Duration::from_secs(0)
                 }
             },
             None => Duration::MAX,


### PR DESCRIPTION
When 2 Tasks are created in very short succession they may not be able to be deleted at the exact time they should expire at.
In this case we should not wait `Duration::MAX` but instead expire the next task as soon as possible.