### PR TITLE
App key syntax

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -49,10 +49,8 @@ services:
     environment:
       BROKER_URL: ${BROKER_URL}
       PROXY_ID: ${PROXY1_ID}
-      APP_0_ID: ${APP1_ID_SHORT}
-      APP_0_KEY: ${APP_KEY}
-      APP_1_ID: ${APP2_ID_SHORT}
-      APP_1_KEY: ${APP_KEY}
+      APP_app1_KEY: ${APP_KEY}
+      APP_app2_KEY: ${APP_KEY}
       PRIVKEY_FILE: /run/secrets/proxy1.pem
       BIND_ADDR: 0.0.0.0:8081
       RUST_LOG: ${RUST_LOG}
@@ -71,10 +69,8 @@ services:
     environment:
       BROKER_URL: ${BROKER_URL}
       PROXY_ID: ${PROXY2_ID}
-      APP_0_ID: ${APP1_ID_SHORT}
-      APP_0_KEY: ${APP_KEY}
-      APP_1_ID: ${APP2_ID_SHORT}
-      APP_1_KEY: ${APP_KEY}
+      APP_app1_KEY: ${APP_KEY}
+      APP_app2_KEY: ${APP_KEY}
       PRIVKEY_FILE: /run/secrets/proxy2.pem
       BIND_ADDR: 0.0.0.0:8082
       RUST_LOG: ${RUST_LOG}

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -55,6 +55,7 @@ clap = { version = "4.0.12", features = ["env", "derive"] }
 
 http = "0.2.8"
 fundu = "0.5.0"
+regex = "1"
 
 [dev-dependencies]
 tokio-test = "0.4.2"

--- a/shared/src/config_proxy.rs
+++ b/shared/src/config_proxy.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use openssl::x509::X509;
+use regex::Regex;
 
 use std::{
     collections::HashMap,
@@ -13,7 +14,7 @@ use std::{
 use axum::http::HeaderValue;
 use hyper::Uri;
 use serde::Deserialize;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::{
     beam_id::{self, AppId, BeamId, BrokerId, ProxyId},
@@ -71,27 +72,33 @@ pub struct CliArgs {
 
 pub const APP_PREFIX: &str = "APP";
 
-/// Parses API-Keys from the environment, expecting:
+/// Parses legacy API-Keys from the environment:
 /// APP_0_ID=app1
 /// APP_0_KEY=App1Secret
 /// APP_1_ID=app2
 /// APP_1_KEY=App2Secret
+/// 
+/// and new API-Keys like:
+/// APP_app1_KEY=App1Secret
+/// APP_app2_KEY=App2Secret
 fn parse_apikeys(proxy_id: &ProxyId) -> Result<HashMap<AppId, ApiKey>, SamplyBeamError> {
-    let vars = std::env::vars().collect::<HashMap<String, ApiKey>>();
+    let env_vars = std::env::vars().collect::<HashMap<String, ApiKey>>();
     let mut api_keys = HashMap::new();
-    let mut i = 0;
-    while let Some(app_id) = vars.get(&format!("{APP_PREFIX}_{i}_ID")) {
-        if let Some(api_key) = vars.get(&format!("{APP_PREFIX}_{i}_KEY")) {
-            let app_id = AppId::new(&format!("{app_id}.{proxy_id}"))?;
-            if api_key.is_empty() {
+    let pattern = Regex::new(&format!("{APP_PREFIX}_([^\\W_]+)_KEY")).expect("This is a valid regex");
+    for (env_var_name, secret) in env_vars {
+        if let Some(app_name) = pattern.captures_iter(&env_var_name).next().and_then(|cap| cap.get(1)) {
+            let Ok(app_id) = AppId::new(&format!("{}.{proxy_id}", app_name.as_str())) else {
+                // Only warn here as there might be other env vars that could match this pattern
+                warn!("Failed to create app id from env var: {env_var_name}. Skipping");
+                continue;
+            };
+            if secret.is_empty() {
                 return Err(SamplyBeamError::ConfigurationFailed(format!(
-                    "Unable to assign empty API key for client {}",
-                    app_id
+                    "Please supply a non empty API key for client {app_id}",
                 )));
             }
-            api_keys.insert(app_id, api_key.clone());
+            api_keys.insert(app_id, secret);
         }
-        i += 1;
     }
     Ok(api_keys)
 }
@@ -108,7 +115,7 @@ impl crate::config::Config for Config {
         })?;
         let api_keys = parse_apikeys(&proxy_id)?;
         if api_keys.is_empty() {
-            return Err(SamplyBeamError::ConfigurationFailed(format!("No API keys have been defined. Please set environment vars à la {0}_0_ID=<clientname>, {0}_0_KEY=<key>", APP_PREFIX)));
+            return Err(SamplyBeamError::ConfigurationFailed(format!("No API keys have been defined. Please set environment vars à la {0}_<clientname>_KEY=<key>", APP_PREFIX)));
         }
         let tls_ca_certificates = crate::crypto::load_certificates_from_dir(
             cli_args.tls_ca_certificates_dir,
@@ -162,10 +169,11 @@ mod tests {
         for (i, (app, key)) in apps.iter().enumerate() {
             std::env::set_var(format!("APP_{i}_ID"), app);
             std::env::set_var(format!("APP_{i}_KEY"), key);
+            std::env::set_var(format!("APP_{app}_KEY"), key);
         }
         const BROKER_ID: &str = "broker.samply.de";
         BrokerId::set_broker_id(BROKER_ID.to_string());
         let parsed = parse_apikeys(&ProxyId::new(&format!("proxy.{BROKER_ID}")).unwrap()).unwrap();
-        assert_eq!(parsed.len(), apps.len());
+        assert_eq!(parsed.len(), apps.len() * 2);
     }
 }


### PR DESCRIPTION
This PR changes the syntax for specifying apps for the proxy from `APP_0_ID=<appID>` and `APP_0_KEY=<secret>` to `APP_<appID>_KEY=<secret>`.

Although old vars like `APP_0_KEY=secret` will still be parsed and registered by the proxy with an `AppId` of 0 I think that this will break pretty much all existing beam apps as they will use their `APP_0_ID` to create the auth header for their requests.