### PR TITLE
Only warn if a tls cert is present but no proxy

### DIFF
--- a/shared/src/http_client.rs
+++ b/shared/src/http_client.rs
@@ -16,7 +16,7 @@ use hyper_tls::{
 use mz_http_proxy::hyper::connector;
 use once_cell::sync::OnceCell;
 use openssl::x509::X509;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::{config, errors::SamplyBeamError, BeamId};
 
@@ -63,7 +63,7 @@ pub fn build(
         .collect::<HashSet<_>>();
 
     if proxies.len() == 0 && ca_certificates.len() > 0 {
-        return Err(std::io::Error::new(std::io::ErrorKind::Other, "Certificates for TLS termination were provided but no proxy to use. Please supply correct configuration."));
+        warn!("Certificates for TLS termination were provided but no proxy to use. If you want to set a proxy see https://docs.rs/mz-http-proxy/0.1.0/mz_http_proxy/#proxy-selection");
     }
 
     let proxies = match proxies.len() {


### PR DESCRIPTION
This is needed for reuse in beam-connect