### PR TITLE
Broker health endpoint for proxy connections

### DIFF
--- a/broker/Cargo.toml
+++ b/broker/Cargo.toml
@@ -19,7 +19,7 @@ uuid = { version = "1.1.2", features = [
 ]}
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-axum = { version = "0.6", features = [ "query" ] }
+axum = { version = "0.6", features = [ "query", "headers" ] }
 #axum-macros = "0.2.2"
 
 anyhow = "*"

--- a/broker/Cargo.toml
+++ b/broker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "broker"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "Apache-2.0"
 documentation = "https://github.com/samply/beam"

--- a/broker/src/health.rs
+++ b/broker/src/health.rs
@@ -1,6 +1,7 @@
-use std::{fmt::Display, sync::Arc, time::Duration};
+use std::{fmt::Display, sync::Arc, time::{Duration, SystemTime}, collections::HashMap};
 
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
+use shared::beam_id::ProxyId;
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
@@ -36,6 +37,17 @@ impl Default for VaultStatus {
 
 pub struct Health {
     pub vault: VaultStatus,
+    pub proxies: HashMap<ProxyId, ProxyStatus>
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProxyStatus {
+    last_active: SystemTime
+}
+impl ProxyStatus {
+    pub fn new() -> ProxyStatus {
+        ProxyStatus { last_active: SystemTime::now() }
+    }
 }
 
 pub struct Senders {
@@ -46,6 +58,7 @@ impl Health {
     pub fn make() -> (Senders, Arc<RwLock<Self>>) {
         let health = Health {
             vault: VaultStatus::default(),
+            proxies: HashMap::default()
         };
         let (vault_tx, mut vault_rx) = tokio::sync::watch::channel(VaultStatus::default());
         let health = Arc::new(RwLock::new(health));

--- a/broker/src/serve_health.rs
+++ b/broker/src/serve_health.rs
@@ -22,7 +22,7 @@ pub(crate) fn router(health: Arc<RwLock<Health>>) -> Router {
     Router::new()
         .route("/v1/health", get(handler))
         .route("/v1/health/proxies/:proxy_id", get(proxy_health))
-        .route("/v1/control", get(get_controll_tasks))
+        .route("/v1/control", get(get_control_tasks))
         .with_state(health)
 }
 
@@ -74,7 +74,7 @@ async fn proxy_health(
     }
 }
 
-async fn get_controll_tasks(
+async fn get_control_tasks(
     State(state): State<Arc<RwLock<Health>>>,
     proxy_auth: Authorized,
 ) -> StatusCode {

--- a/broker/src/serve_health.rs
+++ b/broker/src/serve_health.rs
@@ -83,8 +83,8 @@ async fn get_control_tasks(
         state.write().await.proxies.insert(proxy_id.clone(), ProxyStatus::new());
     }
 
-    // This will in the wait for control tasks for the given proxy
-    tokio::time::sleep(Duration::from_secs(5* 60)).await;
+    // In the future, this will wait for control tasks for the given proxy
+    tokio::time::sleep(Duration::from_secs(60 * 60)).await;
 
     {
         state.write().await.proxies.remove(&proxy_id);

--- a/broker/src/serve_health.rs
+++ b/broker/src/serve_health.rs
@@ -1,10 +1,11 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::{Duration, SystemTime}};
 
-use axum::{extract::State, http::StatusCode, routing::get, Json, Router};
-use serde::Serialize;
+use axum::{extract::{State, Path}, http::StatusCode, routing::get, Json, Router, TypedHeader, headers::{Authorization, authorization::Basic}};
+use serde::{Serialize, Deserialize};
+use shared::{crypto_jwt::Authorized, Msg, beam_id::ProxyId, config::CONFIG_CENTRAL};
 use tokio::sync::RwLock;
 
-use crate::health::{Health, VaultStatus, Verdict};
+use crate::health::{Health, VaultStatus, Verdict, ProxyStatus};
 
 #[derive(Serialize)]
 struct HealthOutput<'a> {
@@ -19,7 +20,8 @@ struct HealthOutputVault<'a> {
 
 pub(crate) fn router(health: Arc<RwLock<Health>>) -> Router {
     Router::new()
-        .route("/v1/health", get(handler))
+        .route("/v1/health", get(handler).post(register_proxy_health))
+        .route("/v1/health/:proxy_id", get(proxy_health))
         .with_state(health)
 }
 
@@ -48,4 +50,31 @@ async fn handler<'a>(
         },
     };
     (statuscode, Json(health_as_json))
+}
+
+
+async fn proxy_health(
+    State(state): State<Arc<RwLock<Health>>>,
+    Path(proxy): Path<ProxyId>,
+    auth: TypedHeader<Authorization<Basic>>
+) -> Result<Json<ProxyStatus>, StatusCode> {
+    if auth.password() != CONFIG_CENTRAL.monitoring_api_key {
+        return Err(StatusCode::UNAUTHORIZED)
+    }
+
+    if let Some(proxy_status) = state.read().await.proxies.get(&proxy) {
+        Ok(Json(proxy_status.clone()))
+    } else {
+        Err(StatusCode::SERVICE_UNAVAILABLE)
+    }
+}
+
+async fn register_proxy_health(
+    State(state): State<Arc<RwLock<Health>>>,
+    proxy_auth: Authorized,
+) -> StatusCode {
+    let proxy_id = proxy_auth.get_from().get_proxy_id(); 
+    state.write().await.proxies.insert(proxy_id, ProxyStatus::new());
+
+    StatusCode::OK
 }

--- a/broker/src/serve_health.rs
+++ b/broker/src/serve_health.rs
@@ -21,7 +21,7 @@ struct HealthOutputVault<'a> {
 pub(crate) fn router(health: Arc<RwLock<Health>>) -> Router {
     Router::new()
         .route("/v1/health", get(handler).post(register_proxy_health))
-        .route("/v1/health/:proxy_id", get(proxy_health))
+        .route("/v1/health/proxies/:proxy_id", get(proxy_health))
         .with_state(health)
 }
 

--- a/dev/beamdev
+++ b/dev/beamdev
@@ -30,6 +30,7 @@ export APP2_P1=${APP2_ID_SHORT}.$PROXY1_ID
 export APP1_P2=${APP1_ID_SHORT}.$PROXY2_ID
 export APP2_P2=${APP2_ID_SHORT}.$PROXY2_ID
 export APP_KEY=App1Secret
+export BROKER_MONITORING_KEY=SuperSecretKey
 export RUST_LOG=${RUST_LOG:-info}
 
 export VAULT_TOKEN=$(echo $RANDOM | md5sum | head -c 20; echo;)

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       NO_PROXY: vault
       PRIVKEY_FILE: /run/secrets/dummy.pem
       BIND_ADDR: 0.0.0.0:8080
+      MONITORING_API_KEY: ${BROKER_MONITORING_KEY}
       RUST_LOG: ${RUST_LOG}
       ALL_PROXY: http://mitmproxy:8080
     secrets:

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxy"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "Apache-2.0"
 documentation = "https://github.com/samply/beam"

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -194,7 +194,8 @@ fn spwan_controller_polling(client: SamplyHttpClient, config: Config) {
                         }
                     };
                 },
-                Err(e) if e.is_timeout() => {
+                // For some reason e.is_timout() does not work
+                Err(e) if e.to_string().contains("timed out") => {
                     debug!("Connection to broker timed out retrying");
                 },
                 Err(e) => {

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -6,11 +6,15 @@ use backoff::{future::retry_notify, ExponentialBackoff};
 use hyper::{body, client::HttpConnector, Client, Method, Request, StatusCode, Uri};
 use hyper_proxy::ProxyConnector;
 use hyper_tls::HttpsConnector;
+use shared::beam_id::AppOrProxyId;
+use shared::{PlainMessage, MsgEmpty, EncryptedMessage};
 use shared::crypto::CryptoPublicPortion;
 use shared::errors::SamplyBeamError;
 use shared::http_client::{self, SamplyHttpClient};
 use shared::{config, config_proxy::Config};
 use tracing::{debug, error, info, warn};
+
+use crate::serve_tasks::sign_request;
 
 mod auth;
 mod banner;
@@ -72,6 +76,7 @@ pub async fn main() -> anyhow::Result<()> {
     } else {
         debug!("Certificate chain successfully initialized and validated");
     }
+    spwan_report_health_to_broker(client.clone(), config.clone());
 
     serve::serve(config, client).await?;
     Ok(())
@@ -161,4 +166,37 @@ async fn get_broker_health(
             resp.status()
         ))),
     }
+}
+
+fn spwan_report_health_to_broker(client: SamplyHttpClient, config: Config) {
+    const REPORT_INTERVAL: Duration = Duration::from_secs(5 * 60);
+    const RETRY_INTERVAL: Duration = Duration::from_secs(60);
+    tokio::spawn(async move {
+        loop {
+            let body = EncryptedMessage::MsgEmpty(MsgEmpty {
+                from: AppOrProxyId::ProxyId(config.proxy_id.clone()),
+            });
+            let (parts, body) = Request::post(format!("{}v1/health", config.broker_uri))
+                .body(body)
+                .expect("To build request successfully")
+                .into_parts();
+
+            let req = sign_request(body, parts, &config, None).await.expect("This should always work");
+            match client.request(req).await {
+                Ok(res) => {
+                    if res.status() != StatusCode::OK {
+                        tokio::time::sleep(REPORT_INTERVAL).await;
+                        warn!("Got unexpected status reporting health to broker: {}", res.status());
+                    } else {
+                        tokio::time::sleep(RETRY_INTERVAL).await;
+                    }
+                },
+                Err(e) => {
+                    warn!("Error reporting health to broker: {e}");
+                    warn!("Retring in {}s", REPORT_INTERVAL.as_secs());
+                    tokio::time::sleep(RETRY_INTERVAL).await;
+                },
+            };
+        }
+    });
 }

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -181,7 +181,7 @@ fn spwan_report_health_to_broker(client: SamplyHttpClient, config: Config) {
                 .expect("To build request successfully")
                 .into_parts();
 
-            let req = sign_request(body, parts, &config, None).await.expect("This should always work");
+            let req = sign_request(body, parts, &config, None).await.expect("Unable to sign request; this should always work");
             match client.request(req).await {
                 Ok(res) => {
                     if res.status() != StatusCode::OK {

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "Apache-2.0"
 documentation = "https://github.com/samply/beam"

--- a/shared/src/config_broker.rs
+++ b/shared/src/config_broker.rs
@@ -50,7 +50,7 @@ struct CliArgs {
     #[clap(long, env, value_parser, default_value = "/run/secrets/root.crt.pem")]
     rootcert_file: PathBuf,
 
-    /// api key for monitoring
+    /// The API key for accessing monitoring endpoints of the broker
     #[clap(long, env, value_parser)]
     monitoring_api_key: Option<String>,
 

--- a/shared/src/config_broker.rs
+++ b/shared/src/config_broker.rs
@@ -65,7 +65,7 @@ pub struct Config {
     pub pki_realm: String,
     pub pki_token: String,
     pub tls_ca_certificates_dir: Option<PathBuf>,
-    pub monitoring_api_key: String,
+    pub monitoring_api_key: Option<String>,
 }
 
 impl crate::config::Config for Config {

--- a/shared/src/config_broker.rs
+++ b/shared/src/config_broker.rs
@@ -52,7 +52,7 @@ struct CliArgs {
 
     /// api key for monitoring
     #[clap(long, env, value_parser)]
-    monitoring_api_key: String,
+    monitoring_api_key: Option<String>,
 
     /// (included for technical reasons)
     #[clap(long, hide(true))]

--- a/shared/src/config_broker.rs
+++ b/shared/src/config_broker.rs
@@ -50,6 +50,10 @@ struct CliArgs {
     #[clap(long, env, value_parser, default_value = "/run/secrets/root.crt.pem")]
     rootcert_file: PathBuf,
 
+    /// api key for monitoring
+    #[clap(long, env, value_parser)]
+    monitoring_api_key: String,
+
     /// (included for technical reasons)
     #[clap(long, hide(true))]
     test_threads: Option<String>,
@@ -61,6 +65,7 @@ pub struct Config {
     pub pki_realm: String,
     pub pki_token: String,
     pub tls_ca_certificates_dir: Option<PathBuf>,
+    pub monitoring_api_key: String,
 }
 
 impl crate::config::Config for Config {
@@ -85,6 +90,7 @@ impl crate::config::Config for Config {
             pki_realm: cli_args.pki_realm,
             pki_token,
             tls_ca_certificates_dir: cli_args.tls_ca_certificates_dir,
+            monitoring_api_key: cli_args.monitoring_api_key,
         };
         Ok(config)
     }


### PR DESCRIPTION
This will break central sites as the new broker requires a `MONITORING_API_KEY` to be set in order to start. Do we want to change that?