### PR TITLE
Only dockerize protected branches.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,6 +112,7 @@ jobs:
 
   docker:
     needs: [ build-rust, pre-check, test ]
+    if: github.ref_protected == true
 
     strategy:
       matrix:


### PR DESCRIPTION
Let's not have hundreds of tags in Docker Hub but rather only build images for protected branches.