### PR TITLE
Monitor ca chain initialization in the broker

### DIFF
--- a/broker/src/health.rs
+++ b/broker/src/health.rs
@@ -19,7 +19,7 @@ impl Default for Verdict {
     }
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 pub enum VaultStatus {
     Ok,
@@ -35,7 +35,7 @@ impl Default for VaultStatus {
     }
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 pub enum InitStatus {
     Unknown,

--- a/broker/src/health.rs
+++ b/broker/src/health.rs
@@ -35,8 +35,23 @@ impl Default for VaultStatus {
     }
 }
 
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum InitStatus {
+    Unknown,
+    FetchingIntermediateCert,
+    Done
+}
+
+impl Default for InitStatus {
+    fn default() -> Self {
+        InitStatus::Unknown
+    }
+}
+
 pub struct Health {
     pub vault: VaultStatus,
+    pub initstatus: InitStatus,
     pub proxies: HashMap<ProxyId, ProxyStatus>
 }
 
@@ -70,35 +85,58 @@ impl ProxyStatus {
 
 pub struct Senders {
     pub vault: tokio::sync::watch::Sender<VaultStatus>,
+    pub init: tokio::sync::watch::Sender<InitStatus>,
 }
 
 impl Health {
     pub fn make() -> (Senders, Arc<RwLock<Self>>) {
         let health = Health {
             vault: VaultStatus::default(),
+            initstatus: InitStatus::default(),
             proxies: HashMap::default()
         };
         let (vault_tx, mut vault_rx) = tokio::sync::watch::channel(VaultStatus::default());
+        let (init_tx, mut init_rx) = tokio::sync::watch::channel(InitStatus::default());
         let health = Arc::new(RwLock::new(health));
         let health2 = health.clone();
+        let health3 = health.clone();
 
         let vault_watcher = async move {
             while vault_rx.changed().await.is_ok() {
                 let new_val = vault_rx.borrow().clone();
                 let mut health = health2.write().await;
-                match &new_val {
+                health.vault = new_val;
+                match &health.vault {
                     VaultStatus::Ok => info!("Vault connection is now healthy"),
                     x => warn!(
                         "Vault connection is degraded: {}",
                         serde_json::to_string(x).unwrap_or_default()
                     ),
                 }
-                health.vault = new_val;
             }
         };
-        tokio::task::spawn(vault_watcher);
 
-        let senders = Senders { vault: vault_tx };
+        tokio::task::spawn(vault_watcher);
+        let initstatus_watcher = async move {
+            while init_rx.changed().await.is_ok() {
+                let new_val = init_rx.borrow().clone();
+                let mut health = health3.write().await;
+                health.initstatus = new_val;
+                match &health.initstatus {
+                    InitStatus::Done => {
+                        info!("Initialization is now complete");
+                        return;
+                    },
+                    x => warn!(
+                        "Still initializing: {}",
+                        serde_json::to_string(x).unwrap_or_default()
+                    ),
+                }
+            }
+        };
+        tokio::task::spawn(initstatus_watcher);
+
+        let senders = Senders { vault: vault_tx, init: init_tx };
         (senders, health)
     }
 }

--- a/broker/src/main.rs
+++ b/broker/src/main.rs
@@ -13,12 +13,9 @@ mod task_manager;
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use backoff::{
-    future::{retry, retry_notify},
-    Error, ExponentialBackoff, ExponentialBackoffBuilder,
-};
-use shared::{config::CONFIG_CENTRAL, *};
-use tokio::sync::RwLock;
+use health::{Senders, InitStatus};
+use shared::{config::CONFIG_CENTRAL, *, errors::SamplyBeamError};
+use tokio::sync::{RwLock, watch};
 use tracing::{error, info, warn};
 
 #[tokio::main]
@@ -27,25 +24,11 @@ pub async fn main() -> anyhow::Result<()> {
     shared::logger::init_logger()?;
     banner::print_banner();
 
-    let (senders, health) = health::Health::make();
-    let cert_getter = crypto::build_cert_getter(senders.vault)?;
+    let (Senders { init: init_status_sender, vault: vault_status_sender}, health) = health::Health::make();
+    let cert_getter = crypto::build_cert_getter(vault_status_sender)?;
 
     shared::crypto::init_cert_getter(cert_getter);
-    tokio::task::spawn(retry_notify(
-        ExponentialBackoff::default(),
-        || async {
-            shared::crypto::init_ca_chain()
-                .await
-                .map_err(|e| backoff::Error::transient(e))
-        },
-        |err: _, dur: Duration| {
-            warn!(
-                "Still trying to initialize CA chain: {}. Retrying in {}s",
-                err,
-                dur.as_secs()
-            )
-        },
-    ));
+    tokio::task::spawn(init_broker_ca_chain(init_status_sender));
     #[cfg(debug_assertions)]
     if shared::examples::print_example_objects() {
         return Ok(());
@@ -56,4 +39,10 @@ pub async fn main() -> anyhow::Result<()> {
     serve::serve(health).await?;
 
     Ok(())
+}
+
+async fn init_broker_ca_chain(sender: watch::Sender<InitStatus>) {
+    sender.send_replace(health::InitStatus::FetchingIntermediateCert);
+    shared::crypto::init_ca_chain().await.expect("Failed to init broker ca chain");
+    sender.send_replace(health::InitStatus::Done);
 }

--- a/shared/src/crypto.rs
+++ b/shared/src/crypto.rs
@@ -502,7 +502,7 @@ pub async fn get_im_cert() -> Result<String, SamplyBeamError> {
 
 #[dynamic(lazy)]
 pub(crate) static CERT_CACHE: Arc<RwLock<CertificateCache>> = {
-    let (tx_refresh, mut rx_refresh) = mpsc::channel::<oneshot::Sender<Result<CertificateCacheUpdate, SamplyBeamError>>>(1);
+    let (tx_refresh, mut rx_refresh) = mpsc::channel::<oneshot::Sender<Result<CertificateCacheUpdate, SamplyBeamError>>>(16);
     let (tx_newcerts, mut rx_newcerts) = mpsc::channel::<()>(1);
     let cc = Arc::new(RwLock::new(CertificateCache::new(tx_refresh).unwrap()));
     let cc2 = cc.clone();


### PR DESCRIPTION
Health endpoint will now return `503 Service not available` if the ca chain has not yet been initialized.

It will now panic if it fails to init the ca chain.

Can we deploy this somewhere and test before we merge it?