### PR TITLE
Better logging

### DIFF
--- a/proxy/src/auth.rs
+++ b/proxy/src/auth.rs
@@ -10,7 +10,7 @@ use shared::{
     config, config_proxy
 };
 
-use tracing::{debug, Span};
+use tracing::{debug, Span, debug_span, warn};
 
 pub(crate) struct AuthenticatedApp(pub(crate) AppId);
 
@@ -25,25 +25,30 @@ impl<S: Send + Sync> FromRequestParts<S> for AuthenticatedApp {
             [(header::WWW_AUTHENTICATE, SCHEME)],
         );
         if let Some(auth) = parts.headers.get(header::AUTHORIZATION) {
-            let auth = auth.to_str().map_err(|_| UNAUTH_ERR)?;
-            let mut auth = auth.split(' ');
-            if auth.next().unwrap_or("") != SCHEME {
+            let auth_str = auth.to_str().map_err(|_| UNAUTH_ERR)?;
+            let mut auth = auth_str.split(' ');
+            if auth.next() != Some(SCHEME) {
+                warn!(auth_str, "Invalid auth scheme");
                 return Err(UNAUTH_ERR);
             }
-            let client_id = auth.next().unwrap_or("");
-            let client_id = AppId::new(client_id).map_err(|_| UNAUTH_ERR)?;
-            let api_key_actual = config::CONFIG_PROXY
-                .api_keys
-                .get(&client_id)
-                .ok_or(UNAUTH_ERR)?;
+            let Some(client_id) = auth.next().and_then(|s| AppId::new(s).ok()) else {
+                warn!(auth_str, "Invalid app id");
+                return Err(UNAUTH_ERR);
+            };
+            let Some(api_key_actual) = config::CONFIG_PROXY.api_keys.get(&client_id) else {
+                warn!("App {client_id} not registered in proxy");
+                return Err(UNAUTH_ERR);
+            };
             let api_key_claimed = auth.next().ok_or(UNAUTH_ERR)?;
             if api_key_claimed != api_key_actual {
+                warn!("App {client_id} provided the wrong api key");
                 return Err(UNAUTH_ERR);
             }
             debug!("Request authenticated (ClientID {})", client_id);
             Span::current().record("from", AppOrProxyId::App(client_id.clone()).hide_broker());
             Ok(Self(client_id))
         } else {
+            warn!("No auth header provided");
             Err(UNAUTH_ERR)
         }
     }

--- a/shared/src/crypto_jwt.rs
+++ b/shared/src/crypto_jwt.rs
@@ -4,7 +4,6 @@ use crate::{
     config_shared::ConfigCrypto,
     crypto::{self, CryptoPublicPortion},
     errors::{CertificateInvalidReason, SamplyBeamError},
-    middleware::{LoggingInfo, ProxyLogger},
     Msg, MsgEmpty, MsgId, MsgSigned,
 };
 use axum::{async_trait, body::HttpBody, extract::{FromRequest, Request}, http::{header, request::Parts, uri::PathAndQuery, HeaderMap, HeaderName, Method, StatusCode, Uri}, BoxError, RequestExt};
@@ -20,7 +19,7 @@ use once_cell::unsync::Lazy;
 use openssl::base64;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, warn, Span};
 
 const ERR_SIG: (StatusCode, &str) = (StatusCode::UNAUTHORIZED, "Signature could not be verified");
 // const ERR_CERT: (StatusCode, &str) = (StatusCode::BAD_REQUEST, "Unable to retrieve matching certificate.");
@@ -126,7 +125,6 @@ pub const JWT_VERIFICATION_OPTIONS: Lazy<VerificationOptions> = Lazy::new(|| Ver
     ..Default::default()
 });
 
-#[tracing::instrument(skip(token_without_extended_signature))]
 /// This verifys a Msg from sent to the Broker
 /// The Message is encoded in the JWT Claims of the body which is a JWT.
 /// There is never really a [`MsgSigned`] involved in Deserializing the message as the signature is just copied from the body JWT.
@@ -165,12 +163,7 @@ pub async fn verify_with_extended_header<M: Msg + DeserializeOwned>(
                 ERR_SIG
             })?;
 
-    req.extensions
-        .remove::<ProxyLogger>()
-        .expect("Should be set by middleware")
-        .send(header_claims.custom.from.clone())
-        .await
-        .expect("Receiver still lives in middleware");
+    Span::current().record("from", header_claims.custom.from.hide_broker());
 
     // Check extra digest
 

--- a/shared/src/crypto_jwt.rs
+++ b/shared/src/crypto_jwt.rs
@@ -1,3 +1,5 @@
+use std::net::{SocketAddr, IpAddr};
+
 use beam_lib::{AppOrProxyId, ProxyId};
 use crate::{
     config,
@@ -6,7 +8,7 @@ use crate::{
     errors::{CertificateInvalidReason, SamplyBeamError},
     Msg, MsgEmpty, MsgId, MsgSigned,
 };
-use axum::{async_trait, body::HttpBody, extract::{FromRequest, Request}, http::{header, request::Parts, uri::PathAndQuery, HeaderMap, HeaderName, Method, StatusCode, Uri}, BoxError, RequestExt};
+use axum::{async_trait, body::HttpBody, extract::{{FromRequest, ConnectInfo, FromRequestParts}, Request}, http::{header, request::Parts, uri::PathAndQuery, HeaderMap, HeaderName, Method, StatusCode, Uri}, BoxError, RequestExt};
 use jwt_simple::{
     claims::JWTClaims,
     prelude::{
@@ -19,7 +21,7 @@ use once_cell::unsync::Lazy;
 use openssl::base64;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
-use tracing::{debug, error, warn, Span};
+use tracing::{debug, error, warn, Span, info_span};
 
 const ERR_SIG: (StatusCode, &str) = (StatusCode::UNAUTHORIZED, "Signature could not be verified");
 // const ERR_CERT: (StatusCode, &str) = (StatusCode::BAD_REQUEST, "Unable to retrieve matching certificate.");
@@ -133,17 +135,20 @@ pub async fn verify_with_extended_header<M: Msg + DeserializeOwned>(
     req: &mut Parts,
     token_without_extended_signature: &str,
 ) -> Result<MsgSigned<M>, (StatusCode, &'static str)> {
+    let ip = get_ip(req).await;
+    // let a = _span.entered();
     let token_with_extended_signature = std::str::from_utf8(
         req.headers
             .get(header::AUTHORIZATION)
             .ok_or_else(|| {
-                warn!("Missing Authorization header (in verify_with_extended_header)");
+                warn!(%ip, "Missing Authorization header (in verify_with_extended_header)");
                 ERR_SIG
             })?
             .as_bytes(),
     )
     .map_err(|e| {
         warn!(
+            %ip,
             "Unable to parse existing Authorization header (in verify_with_extended_header): {}",
             e
         );
@@ -157,6 +162,7 @@ pub async fn verify_with_extended_header<M: Msg + DeserializeOwned>(
             .await
             .map_err(|e| {
                 warn!(
+                    %ip,
                     "Unable to extract header JWT: {}. The full JWT was: {}. The header was: {:?}",
                     e, token_with_extended_signature, req
                 );
@@ -305,4 +311,15 @@ pub fn make_extra_fields_digest(
         sig: digest,
         from: from.to_owned(),
     })
+}
+
+async fn get_ip(parts: &mut Parts) -> IpAddr {
+    let source_ip = ConnectInfo::<SocketAddr>::from_request_parts(parts, &()).await.expect("The server is configured to keep connect info").0.ip();
+    const X_FORWARDED_FOR: HeaderName = HeaderName::from_static("x-forwarded-for");
+    parts.headers
+        .get(X_FORWARDED_FOR)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.split(',').next())
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(source_ip)
 }

--- a/shared/src/logger.rs
+++ b/shared/src/logger.rs
@@ -1,8 +1,14 @@
 use tracing::{debug, dispatcher::SetGlobalDefaultError, Level};
+use tracing_subscriber::fmt::format::{debug_fn, self};
 
 #[allow(clippy::if_same_then_else)] // The redundant if-else serves documentation purposes
 pub fn init_logger() -> Result<(), SetGlobalDefaultError> {
-    let subscriber = tracing_subscriber::FmtSubscriber::builder().with_max_level(Level::DEBUG);
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .fmt_fields(debug_fn(|w, f, v| match f.name() {
+            "from" | "message" => write!(w, "{v:?}"),
+            _ => write!(w, "{f}={v:?} "),
+        }))
+        .with_max_level(Level::DEBUG);
 
     // TODO: Reduce code complexity.
     let env_filter = match std::env::var("RUST_LOG") {

--- a/shared/src/middleware.rs
+++ b/shared/src/middleware.rs
@@ -1,111 +1,28 @@
-use std::{
-    cell::RefCell,
-    net::{IpAddr, SocketAddr},
-    sync::Arc,
-};
-
 use axum::{
-    body::HttpBody,
-    extract::{ConnectInfo, Request},
-    http::{header::HeaderName, Method, StatusCode, Uri},
-    middleware::{self, Next},
-    response::{IntoResponse, Response},
+    extract::Request,
+    http::StatusCode,
+    middleware::Next,
+    response::Response,
 };
-use tokio::sync::mpsc;
-use tracing::{error, info, instrument, span, warn, Level};
-
-use beam_lib::AppOrProxyId;
-
-const X_FORWARDED_FOR: HeaderName = HeaderName::from_static("x-forwarded-for");
-
-pub struct LoggingInfo {
-    // Known from the start
-    method: Method,
-    uri: Uri,
-    ip: IpAddr,
-
-    // Added by SignedMsg extractor
-    from_proxy: Option<AppOrProxyId>,
-
-    // Added after handlers
-    status_code: Option<StatusCode>,
-}
-
-impl LoggingInfo {
-    fn new(method: Method, uri: Uri, ip: IpAddr) -> Self {
-        Self {
-            method,
-            uri,
-            ip,
-            from_proxy: None,
-            status_code: None,
-        }
-    }
-
-    fn set_status_code(&mut self, status: StatusCode) {
-        self.status_code = Some(status);
-    }
-
-    fn set_proxy_name(&mut self, proxy: AppOrProxyId) {
-        self.from_proxy = Some(proxy);
-    }
-
-    fn get_log(&self) -> String {
-        let from = self
-            .from_proxy
-            .as_ref()
-            .map(|id| id.hide_broker())
-            .unwrap_or(self.ip.to_string());
-        format!(
-            "{} {} {} {}",
-            from,
-            self.status_code
-                .expect("Did not set Statuscode before logging"),
-            self.method,
-            self.uri
-        )
-    }
-}
-
-pub type ProxyLogger = mpsc::Sender<AppOrProxyId>;
+use tracing::{info, warn, info_span, field, Instrument, Span};
 
 pub async fn log(
-    ConnectInfo(info): ConnectInfo<SocketAddr>,
-    mut req: Request,
+    req: Request,
     next: Next,
 ) -> Response {
     let method = req.method().clone();
     let uri = req.uri().clone();
-    let ip = get_ip(&req, &info);
+    let span = info_span!("", from = field::Empty);
 
-    let mut info = LoggingInfo::new(method, uri, ip);
-    // This channel may or may not receive an AppOrProxyId from verify_with_extended_header
-    // TODO: Solve this with tracing
-    let (tx, mut rx) = mpsc::channel(1);
-    req.extensions_mut().insert(tx);
-
-    let resp = next.run(req).await;
-    info.set_status_code(resp.status());
-
-    if let Ok(proxy) = rx.try_recv() {
-        info.set_proxy_name(proxy);
-    }
-
-    let line = info.get_log();
-    // If we get a gateway timeout we won't log it with log level warn as this happens regularly with the long polling api
-    if resp.status().is_success() || resp.status().is_informational() || resp.status() == StatusCode::GATEWAY_TIMEOUT {
-        info!(target: "in", "{}", line);
-    } else {
-        warn!(target: "in", "{}", line);
-    }
-    resp
-}
-
-fn get_ip(req: &Request, info: &SocketAddr) -> IpAddr {
-    req.headers()
-        .get(X_FORWARDED_FOR)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.split(',').next())
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(info.ip())
+    async move {
+        let resp = next.run(req).instrument(Span::current()).await;
+        let status = resp.status();
+        // If we get a gateway timeout we won't log it with log level warn as this happens regularly with the long polling api
+        if status.is_success() || status.is_informational() || status == StatusCode::GATEWAY_TIMEOUT {
+            info!(target: "in", "{method} {uri} {status}");
+        } else {
+            warn!(target: "in", "{method} {uri} {status}");
+        };
+        resp
+    }.instrument(span).await
 }


### PR DESCRIPTION
This now fully utilizes tracing for recording log messages.
The one downside this has is that we aren't able to show the IP Address as a fallback if the request does not get authenticated.
The upside is that all other log messages within this `Span` now automatically show the spans recorded context which in this case is which app issued the request.

I am also considering adding `url` and `method` to the spans context as that might be useful for debugging but I didn't like the way the spans fields were formatted for the common request logging case.