### PR TITLE
Upgrade to libssl3 and add `beamdev restart`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,7 @@ name: Build with rust and docker
 
 on:
   push:
+  workflow_dispatch:
   pull_request:
   schedule:
     # Fetch new base image updates every night at 1am
@@ -22,7 +23,7 @@ jobs:
 
   build-rust:
     name: Build (Rust)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -110,7 +111,7 @@ jobs:
   test:
     name: Run tests
     needs: [ build-rust ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -130,14 +131,11 @@ jobs:
         with:
           name: testbinaries-amd64-${{ matrix.features }}
           path: testbinaries/
-      - name: Get newer curl version
-        run: |
-          curl -L https://github.com/stunnel/static-curl/releases/download/8.2.0/curl-static-amd64-8.2.0.tar.xz | sudo tar xJ -C /usr/local/bin/
       - run: ./dev/test ci ${{ matrix.features && format('--features {0}', matrix.features) }}
 
   docker:
     needs: [ build-rust, pre-check, test ]
-    if: github.ref_protected == true
+    if: github.ref_protected == true || github.event_name == 'workflow_dispatch'
 
     strategy:
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   pre-check:
     name: Security, License Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
 
   build-rust:
     name: Build (Rust)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -111,7 +111,7 @@ jobs:
   test:
     name: Run tests
     needs: [ build-rust ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 # This assumes binaries are present, see COPY directive.
 
-ARG IMGNAME=gcr.io/distroless/cc-debian12
-
 FROM alpine AS chmodder
 ARG FEATURE
 ARG TARGETARCH
@@ -9,6 +7,6 @@ ARG COMPONENT
 COPY /artifacts/binaries-$TARGETARCH$FEATURE/$COMPONENT /app/component
 RUN chmod +x /app/*
 
-FROM ${IMGNAME}
+FROM gcr.io/distroless/cc-debian12
 COPY --from=chmodder /app/component /usr/local/bin/
 ENTRYPOINT [ "/usr/local/bin/component" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This assumes binaries are present, see COPY directive.
 
-ARG IMGNAME=gcr.io/distroless/cc
+ARG IMGNAME=gcr.io/distroless/cc-debian12
 
 FROM alpine AS chmodder
 ARG FEATURE

--- a/dev/beamdev
+++ b/dev/beamdev
@@ -40,18 +40,6 @@ export P2="http://localhost:8082" # for scripts
 
 export ARCH=$(docker version --format "{{.Server.Arch}}")
 
-function image_for_docker() {
-     # Pick the correct Ubuntu version for the Docker image,
-     # so the locally-built rust binary works regarding libssl
-     if [[ "$(pkg-config --modversion libssl)" =~ ^3.* ]]; then
-          echo "ubuntu:latest" # Use libssl3
-     else
-          echo -n "" # Don't change (uses libssl1.1)
-     fi
-}
-
-export IMGNAME="$(image_for_docker)"
-
 function check_prereqs() {
      set +e
      if [[ "$(curl --version)" != *" libcurl/"* ]]; then
@@ -105,11 +93,7 @@ function build() {
 function build_docker() {
     BACK2=$(pwd)
     cd $SD
-    if [ -z "$IMGNAME" ]; then
-        docker-compose build --build-arg TARGETARCH=$ARCH
-    else
-        docker-compose build --build-arg TARGETARCH=$ARCH --build-arg IMGNAME=$IMGNAME
-    fi
+    docker-compose build --build-arg TARGETARCH=$ARCH
     cd $BACK2
 }
 
@@ -123,7 +107,8 @@ function start {
     pki/pki devsetup
     echo "$VAULT_TOKEN" > ./pki/pki.secret
     build $@
-    docker-compose up --no-build --no-recreate --abort-on-container-exit
+    docker compose up --no-build --no-recreate -d
+    docker compose logs -f
 }
 
 function demo {
@@ -291,6 +276,11 @@ case "$1" in
     shift
     start_bg $@
     ;;
+  restart)
+    shift
+    build $@
+    docker compose up --no-deps --no-build proxy1 proxy2 broker
+    ;;
   clean)
     clean
     ;;
@@ -307,6 +297,6 @@ case "$1" in
     defaults
     ;;
   *)
-    echo "Usage: $0 [--tag SOMETAG, e.g. develop, to use an existing image] build|start|start_bg|stop|clean|defaults|noop"
+    echo "Usage: $0 [--tag SOMETAG, e.g. develop, to use an existing image] build|start|start_bg|restart|stop|clean|defaults|noop"
     ;;
 esac

--- a/dev/test
+++ b/dev/test
@@ -6,8 +6,6 @@ cd $SD
 
 source beamdev noop
 
-unset IMGNAME
-
 function start() {
   trap "echo; echo; clean" EXIT
   start_bg


### PR DESCRIPTION
- Update CI to use libssl 3
- Added a workflow dispatch trigger (This lets you trigger CI manually in the Actions tab) that can run our CI and will publish an image to dockerhub for testing without requiring the branch to be protected
- Added `beamdev restart` which will rebuild beam and update the running images without restarting the vault
