### PR TITLE
Metadata for sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ While "regular" Beam Tasks transport application data, Socket Task initiate dire
     "to": ["app2.proxy2.broker"],
     "id": "<socket_uuid>",
     "ttl": "60s",
+    "metadata": "some custom json value"
 }
 ```
 
@@ -286,6 +287,7 @@ While "regular" Beam Tasks transport application data, Socket Task initiate dire
 - `to`: BeamIDs of the intended recipients. Due to the nature of socket connections, the array has to be of exact length 1.
 - `id`: A UUID v4 which identifies the socket connection and is used by the recipient to connect to this socket (see [here](#connecting-to-a-socket-request)).
 - `ttl`: The time-to-live of this socket task. After this time has elapsed the recipient can no longer connect to the socket. Already established connections are not affected.
+- `metadata`: Associated unencrypted data. Can be of arbitrary type same as in [Task](#task).
 ## API
 
 ### Create task
@@ -522,6 +524,8 @@ Initialize a socket connection with an Beam application, e.g. with AppId `app2.p
 Method: `POST`  
 URL: `/v1/sockets/<app_id>`  
 Header `Upgrade` is required, e.g. 'Upgrade: tls'
+Optionally takes a `metadata` header which is expected to be serialized json value.
+This corresponds to the `metadata` field on [Socket task](#socket-task).
 
 This request will automatically lead to a connection to the other app, after it answers this request.
 
@@ -539,9 +543,10 @@ Returns an array of JSON objects:
 [
     {
         "from": "app1.proxy1.broker",
-        "to": ["app2.proxy2.broker"]
+        "to": ["app2.proxy2.broker"],
         "id": "<socket_uuid>",
         "ttl": "60s",
+        "metadata": "Some json value"
     }
 ]
 ```

--- a/beam-lib/src/http_util.rs
+++ b/beam-lib/src/http_util.rs
@@ -191,7 +191,7 @@ impl BeamClient {
         self.create_socket_with_metadata(destination, serde_json::Value::Null).await
     }
 
-    /// Same as `create_socket` but with metadata.
+    /// Same as `create_socket` but with associated (unencrypted) metadata.
     #[cfg(feature = "sockets")]
     pub async fn create_socket_with_metadata(&self, destination: &AddressingId, metadata: impl Serialize) -> Result<reqwest::Upgraded> {
         const METADATA_HEADER: HeaderName = HeaderName::from_static("metadata");

--- a/beam-lib/src/ids.rs
+++ b/beam-lib/src/ids.rs
@@ -129,6 +129,7 @@ fn strip_broker_id(id: &str) -> Result<&str, BeamIdError> {
     }
 }
 
+#[cfg(feature = "strict-ids")]
 #[derive(PartialEq, Debug)]
 pub(crate) enum BeamIdType {
     AppId,

--- a/beam-lib/src/messages.rs
+++ b/beam-lib/src/messages.rs
@@ -54,6 +54,8 @@ pub struct SocketTask {
     pub to: Vec<AddressingId>,
     pub ttl: String,
     pub id: MsgId,
+    #[serde(default)]
+    pub metadata: Value,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/shared/src/serializing_compatibility_test.rs
+++ b/shared/src/serializing_compatibility_test.rs
@@ -109,12 +109,14 @@ fn test_socket_task() {
         secret: Plain { body: None },
         expire: SystemTime::now() + Duration::from_secs(10),
         id,
+        metadata: serde_json::Value::Null
     };
     let lib = beam_lib::SocketTask {
         from,
         to: vec![],
         ttl: "9".to_string(),
         id,
+        metadata: serde_json::Value::Null
     };
     let a_str = serde_json::to_string(&lib).unwrap();
     let b_str = serde_json::to_string(&internal).unwrap();

--- a/shared/src/sockets.rs
+++ b/shared/src/sockets.rs
@@ -18,6 +18,8 @@ where State: MsgState {
     pub id: MsgId,
     #[serde(skip_serializing_if = "MsgState::is_empty")]
     pub secret: State,
+    #[serde(default)]
+    pub metadata: Value
 }
 
 impl<State: MsgState> Msg for MsgSocketRequest<State> {
@@ -30,7 +32,7 @@ impl<State: MsgState> Msg for MsgSocketRequest<State> {
     }
 
     fn get_metadata(&self) -> &Value {
-        &Value::Null
+        &self.metadata
     }
 }
 
@@ -42,8 +44,8 @@ impl DecryptableMsg for MsgSocketRequest<Encrypted> {
     }
 
     fn convert_self(self, body: String) -> Self::Output {
-        let Self { from, to, expire, id, .. } = self;
-        Self::Output { from, to, expire, secret: body.into(), id }
+        let Self { from, to, expire, id, metadata, .. } = self;
+        Self::Output { from, to, expire, secret: body.into(), id, metadata }
     }
 }
 
@@ -51,8 +53,8 @@ impl EncryptableMsg for MsgSocketRequest<Plain> {
     type Output = MsgSocketRequest<Encrypted>;
 
     fn convert_self(self, body: Encrypted) -> Self::Output {
-        let Self { from, to, expire, id, .. } = self;
-        Self::Output { from, to, expire, secret: body, id }
+        let Self { from, to, expire, id, metadata, .. } = self;
+        Self::Output { from, to, expire, secret: body, id, metadata }
     }
 
     fn get_plain(&self) -> &Plain {


### PR DESCRIPTION
- feat: Add metadata support to sockets
- fix(beam-lib): Only enable IdType with strict ids
