### PR TITLE
Cargo-deny: ignore RUSTSEC-2023-0071 advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -49,6 +49,7 @@ notice = "warn"
 # output a note when they are encountered.
 ignore = [
     "RUSTSEC-2020-0071", #used only by build-data as a build dependency
+    "RESTSEC-2023-0071", #Currently no patch available, but impratical attack for OAEP and 2k keys 
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/deny.toml
+++ b/deny.toml
@@ -49,7 +49,7 @@ notice = "warn"
 # output a note when they are encountered.
 ignore = [
     "RUSTSEC-2020-0071", #used only by build-data as a build dependency
-    "RESTSEC-2023-0071", #Currently no patch available, but impratical attack for OAEP and 2k keys 
+    "RUSTSEC-2023-0071", #Currently no patch available, but impratical attack for OAEP and 2k keys 
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
Currently no patched version of the rsa crate affected by the side-channel attack published as [RUSTSEC-2023-0071](https://rustsec.org/advisories/RUSTSEC-2023-0071) exists, but we use OAEP with either 2048 or 4096 bit keys, which is deemed [impractical by the security researcher](https://github.com/RustCrypto/RSA/issues/19#issuecomment-1824341149). Hence, this PR adds it to the cargo-deny ignore list for the time being.