### PR TITLE
chore: Upgrade http ecosystem to hyper 1

### DIFF
--- a/beam-lib/Cargo.toml
+++ b/beam-lib/Cargo.toml
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-uuid = { version = "1.3.4", features = ["v4", "serde"] }
-reqwest = { version = "0.11.20", features = ["json"], default-features = false, optional = true }
+uuid = { version = "1", features = ["v4", "serde"] }
+reqwest = { version = "0.12", features = ["json"], default-features = false, optional = true }
 thiserror = { version = "1.0", optional = true }
 
 [features]

--- a/broker/Cargo.toml
+++ b/broker/Cargo.toml
@@ -12,39 +12,30 @@ shared = { path = "../shared", features = ["config-for-central"] }
 beam-lib = { workspace = true }
 
 tokio = { version = "1", features = ["full"] }
-uuid = { version = "1.1.2", features = [
-    "v4",                # Lets you generate random UUIDs
-    "fast-rng",          # Use a faster (but still sufficiently random) RNG
-    "macro-diagnostics", # Enable better diagnostics for compile-time UUIDs
-    "serde"
-]}
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-axum = { version = "0.6", features = [ "query", "headers" ] }
+axum = { version = "0.7", features = [ "query" ] }
 #axum-macros = "0.3.7"
 dashmap =  "5.4"
 
-anyhow = "*"
-thiserror = "1.0.31"
-backoff = { version = "0.4.0", features = ["tokio"] }
+anyhow = "1"
+thiserror = "1"
 
-# Logging is imported through shared
-tracing = "0.1.35"
-#tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
-
-hyper = { version = "0.14.19", features = ["full"] }
-hyper-tls = "0.5.0"
-hyper-proxy = "0.9.1"
+# Subscriber is setup through shared
+tracing = "0.1"
 
 # Server-sent Events (SSE) support
-async-stream = "0.3.4"
-futures-core = { version = "0.3.26", default-features = false }
-once_cell = "1.17.1"
+async-stream = "0.3"
+futures-core = { version = "0.3", default-features = false }
+once_cell = "1"
 # Socket dependencies
-bytes = { version = "1.4.0", optional = true }
+bytes = { version = "1", optional = true }
+axum-extra = { version = "0.9", features = ["typed-header"] }
+hyper = { version = "1", default-features = false, optional = true}
+hyper-util = { version = "0.1", default-features = false, features = ["tokio"], optional = true}
 
 [features]
-sockets = ["dep:bytes", "shared/sockets"]
+sockets = ["dep:bytes", "shared/sockets", "dep:hyper", "dep:hyper-util"]
 
 [build-dependencies]
 build-data = "0"

--- a/broker/src/banner.rs
+++ b/broker/src/banner.rs
@@ -1,5 +1,4 @@
-use axum::{http::HeaderValue, response::Response};
-use hyper::header;
+use axum::{http::{header, HeaderValue}, response::Response};
 use tracing::info;
 
 pub(crate) fn print_banner() {

--- a/broker/src/compare_client_server_version.rs
+++ b/broker/src/compare_client_server_version.rs
@@ -1,5 +1,4 @@
-use axum::{middleware::Next, response::Response};
-use hyper::{header, Request, Body, http::HeaderValue};
+use axum::{http::{header, HeaderValue}, middleware::Next, response::Response, extract::Request};
 use tracing::{debug, warn};
 
 enum Verdict {
@@ -37,8 +36,8 @@ fn compare_version(their_version_header: &HeaderValue) -> Verdict {
 }
 
 pub(crate) async fn log_version_mismatch(
-    req: Request<Body>,
-    next: Next<Body>,
+    req: Request,
+    next: Next,
 ) -> Response {
     let user_agent = req.headers().get(header::USER_AGENT);
 

--- a/broker/src/serve_health.rs
+++ b/broker/src/serve_health.rs
@@ -1,6 +1,7 @@
 use std::{sync::Arc, time::{Duration, SystemTime}};
 
-use axum::{extract::{State, Path}, http::StatusCode, routing::get, Json, Router, TypedHeader, headers::{Authorization, authorization::Basic}, response::Response};
+use axum::{extract::{State, Path}, http::StatusCode, routing::get, Json, Router, response::Response};
+use axum_extra::{headers::{authorization::Basic, Authorization}, TypedHeader};
 use beam_lib::ProxyId;
 use serde::{Serialize, Deserialize};
 use shared::{crypto_jwt::Authorized, Msg, config::CONFIG_CENTRAL};

--- a/broker/src/serve_pki.rs
+++ b/broker/src/serve_pki.rs
@@ -4,13 +4,11 @@ use std::{convert::Infallible, net::SocketAddr, string::FromUtf8Error};
 
 use axum::{
     extract::{ConnectInfo, Path, Query},
-    http::Request,
+    http::{Request, StatusCode},
     response::{IntoResponse, Response},
     routing::{get, Route},
     Extension, Json, Router,
 };
-use hyper::{client::HttpConnector, Body, Client, StatusCode};
-use hyper_tls::HttpsConnector;
 use serde::{Deserialize, Serialize};
 use shared::{
     config::CONFIG_CENTRAL,

--- a/broker/src/serve_tasks.rs
+++ b/broker/src/serve_tasks.rs
@@ -6,14 +6,13 @@ use std::{
 use axum::{
     extract::ConnectInfo,
     extract::{Path, Query, State},
-    http::{header, HeaderValue, StatusCode},
+    http::{header, HeaderValue, StatusCode, HeaderMap},
     response::{sse::Event, IntoResponse, Response, Sse},
     routing::{get, post, put},
     Json, Router,
 };
 use beam_lib::AppOrProxyId;
 use futures_core::{stream, Stream};
-use hyper::HeaderMap;
 use serde::Deserialize;
 use beam_lib::WorkStatus;
 use shared::{

--- a/broker/src/task_manager.rs
+++ b/broker/src/task_manager.rs
@@ -4,10 +4,9 @@ use std::{
     time::{Duration, SystemTime}, collections::HashMap, sync::Arc, convert::Infallible,
 };
 
-use axum::{response::{IntoResponse, sse::Event, Sse}, Json};
+use axum::{response::{IntoResponse, sse::Event, Sse}, Json, http::StatusCode};
 use dashmap::DashMap;
 use futures_core::Stream;
-use hyper::StatusCode;
 use once_cell::sync::Lazy;
 use serde::Serialize;
 use serde_json::json;

--- a/dev/test_3_fetch_with_sse.sh
+++ b/dev/test_3_fetch_with_sse.sh
@@ -10,7 +10,7 @@ if [ "$CODE" != "200" ]; then
     fail "$RET" Unable to fetch the existing task as app1.proxy1 via SSE
 fi
 
-EVENT_LINES=$(echo "$BODY" | grep '^event:' | sed 's/^event://g')
+EVENT_LINES=$(echo "$BODY" | grep '^event:' | sed 's/^event://g' | awk '{$1=$1;print}')
 COUNT=0
 IFS=$'\n'
 for LINE in $EVENT_LINES; do
@@ -64,7 +64,7 @@ if [ "$CODE" != "200" ]; then
     fail "$RET" Unable to fetch partial results as app1.proxy1 via SSE
 fi
 
-EVENT_LINES=$(echo "$BODY" | grep '^event:' | sed 's/^event://g')
+EVENT_LINES=$(echo "$BODY" | grep '^event:' | sed 's/^event://g' | awk '{$1=$1;print}')
 COUNT=0
 EXPIRED_COUNT=0
 IFS=$'\n'

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -12,45 +12,38 @@ shared = { path = "../shared", features = ["config-for-proxy"] }
 beam-lib = { workspace = true }
 
 tokio = { version = "1", features = ["full"] }
-async-recursion = "1.0.0"
-axum = { version = "0.6", features = ["macros"] }
-hyper = { version = "0.14.19", features = ["full"] }
-
-# for HTTP client
-hyper-tls = "0.5.0"
-httpdate = "1.0.2"
-hyper-proxy = "0.9.1"
+axum = { version = "0.7", features = ["macros"] }
+bytes = { version = "1" }
+httpdate = "1.0"
 
 # Error handling
-thiserror = "1.0.31"
-anyhow = "1.0.58"
-backoff = { version = "0.4.0", features = ["tokio"] }
+anyhow = "1"
+backoff = { version = "0.4", features = ["tokio"] }
 
-# Logging is imported through shared
-tracing = "0.1.35"
-#tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
+# Subscriber is imported through shared
+tracing = "0.1"
 
 # Config file parsing
 serde = "1"
 serde_json = "1"
 
 # Encryption handling
-rsa = "0.9.2"
+rsa = "0.9"
 
 # Server-sent Events (SSE) support
-tokio-util = { version = "0.7.7", features = ["io"] }
-futures = "0.3.26"
-async-sse = "5.1.0"
-async-stream = "0.3.4"
+tokio-util = { version = "0.7", features = ["io"] }
+futures = "0.3"
+async-sse = "5.1"
+async-stream = "0.3"
 
 # Socket dependencies
-chacha20poly1305 = { version = "0.10.1", features = ["stream"], optional = true }
-bytes = { version = "1.4", optional = true}
-dashmap =  { version = "5.4", optional = true}
-
+chacha20poly1305 = { version = "0.10", features = ["stream"], optional = true }
+dashmap =  { version = "5.5", optional = true}
+hyper = { version = "1", default-features = false, optional = true }
+hyper-util = { version = "0.1", default-features = false, features = ["tokio"], optional = true}
 
 [features]
-sockets = ["dep:bytes", "dep:chacha20poly1305", "dep:dashmap", "tokio-util/codec", "tokio-util/compat", "shared/sockets", "shared/expire_map"]
+sockets = ["dep:chacha20poly1305", "dep:dashmap", "tokio-util/codec", "tokio-util/compat", "shared/sockets", "shared/expire_map", "dep:hyper", "dep:hyper-util"]
 
 [build-dependencies]
 build-data = "0"

--- a/proxy/src/auth.rs
+++ b/proxy/src/auth.rs
@@ -3,11 +3,7 @@ use std::collections::HashMap;
 use axum::{
     async_trait,
     extract::{FromRequest, FromRequestParts},
-    http::request::Parts,
-};
-use hyper::{
-    header::{self, HeaderName},
-    Request, StatusCode,
+    http::{header::{self, HeaderName}, request::Parts, Request, StatusCode},
 };
 use beam_lib::{AppId, AppOrProxyId};
 use shared::{

--- a/proxy/src/banner.rs
+++ b/proxy/src/banner.rs
@@ -1,5 +1,4 @@
-use axum::{http::HeaderValue, response::Response};
-use hyper::header;
+use axum::{http::{HeaderValue, header}, response::Response};
 use tracing::info;
 
 pub(crate) fn print_banner() {

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -179,7 +179,6 @@ fn spawn_controller_polling(client: SamplyHttpClient, config: Config) {
                         }
                     };
                 },
-                // For some reason e.is_timeout() does not work
                 Err(e) if e.is_timeout() => {
                     debug!("Connection to broker timed out; retrying: {e}");
                 },

--- a/proxy/src/serve_health.rs
+++ b/proxy/src/serve_health.rs
@@ -1,5 +1,4 @@
-use axum::{routing::get, Router};
-use hyper::StatusCode;
+use axum::{http::StatusCode, routing::get, Router};
 
 pub(crate) fn router() -> Router {
     Router::new().route("/v1/health", get(handler_health))

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -8,61 +8,50 @@ documentation = "https://github.com/samply/beam"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-uuid = { version = "1.1.2", features = [
+uuid = { version = "1", features = [
     "v4",                # Lets you generate random UUIDs
     "fast-rng",          # Use a faster (but still sufficiently random) RNG
-    "macro-diagnostics", # Enable better diagnostics for compile-time UUIDs
     "serde"
 ]}
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 tokio = { version = "1", features = ["full"] }
-axum = { version = "0.6", features = ["macros", "headers"] }
-hyper = { version = "0.14.19", features = ["full"] }
+axum = { version = "0.7", features = [] }
 bytes = "1.4"
 
 # HTTP client with proxy support
-hyper-tls = "0.5.0"
-hyper-proxy = "0.9.1"
-mz-http-proxy = { version = "0.1.0", features = ["hyper"] }
-hyper-timeout = "0.4"
+reqwest = { version = "0.12", features = ["stream"] }
 
 # Logging
-tracing = "0.1.35"
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Crypto
-rand = "0.8.5"
-rsa = "0.9.2"
-sha2 = "0.10.2"
-openssl = "0.10.40"
-chacha20poly1305 = "0.10.1"
+rand = "0.8"
+rsa = "0.9"
+sha2 = "0.10"
+openssl = "0.10"
+chacha20poly1305 = "0.10"
 itertools = "0.12.0"
-jwt-simple = "0.11.1"
+jwt-simple = "0.11"
 
 # Global variables
-static_init = "1.0.2"
-once_cell = "1.13.0"
+once_cell = "1"
 
 # Error handling
-thiserror = "1.0.31"
-anyhow = "1.0.58"
+thiserror = "1"
 
 # Command Line Interface
-clap = { version = "4.0.12", features = ["env", "derive"] }
+clap = { version = "4", features = ["env", "derive"] }
 
-http = "0.2.8"
-fundu = "2.0.0"
+fundu = "2.0"
 regex = "1"
 
 # expire map dependencies
 dashmap =  { version = "5.4", optional = true}
 
 beam-lib = { workspace = true }
-
-[dev-dependencies]
-tokio-test = "0.4.2"
 
 [features]
 expire_map = ["dep:dashmap"]

--- a/shared/src/config.rs
+++ b/shared/src/config.rs
@@ -1,5 +1,4 @@
-use once_cell::sync::OnceCell;
-use static_init::dynamic;
+use once_cell::sync::{Lazy, OnceCell};
 use tracing::debug;
 
 use crate::{
@@ -21,23 +20,20 @@ fn load<T: Config>() -> T where {
         })
 }
 
-#[dynamic(lazy)]
-pub static CONFIG_PROXY: config_proxy::Config = {
+pub static CONFIG_PROXY: Lazy<config_proxy::Config> = Lazy::new(|| {
     debug!("Loading config CONFIG_PROXY");
     load()
-};
+});
 
-#[dynamic(lazy)]
-pub static CONFIG_CENTRAL: config_broker::Config = {
+pub static CONFIG_CENTRAL: Lazy<config_broker::Config> = Lazy::new(|| {
     debug!("Loading config CONFIG_CENTRAL");
     load()
-};
+});
 
-#[dynamic(lazy)]
-pub static CONFIG_SHARED: config_shared::Config = {
+pub static CONFIG_SHARED: Lazy<config_shared::Config> = Lazy::new(|| {
     debug!("Loading config CONFIG_SHARED");
     load()
-};
+});
 
 pub(crate) static CONFIG_SHARED_CRYPTO: OnceCell<ConfigCrypto> = OnceCell::new();
 

--- a/shared/src/config_broker.rs
+++ b/shared/src/config_broker.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use axum::http::Uri;
 use clap::Parser;
-use static_init::dynamic;
+use reqwest::Url;
 use std::str::FromStr;
 use tracing::info;
 
@@ -31,7 +31,7 @@ struct CliArgs {
 
     /// samply.pki: URL to HTTPS endpoint
     #[clap(long, env, value_parser)]
-    pki_address: Uri,
+    pki_address: Url,
 
     /// samply.pki: Authentication realm
     #[clap(long, env, value_parser, default_value = "samply_pki")]
@@ -60,7 +60,7 @@ struct CliArgs {
 
 pub struct Config {
     pub bind_addr: SocketAddr,
-    pub pki_address: Uri,
+    pub pki_address: Url,
     pub pki_realm: String,
     pub pki_token: String,
     pub tls_ca_certificates_dir: Option<PathBuf>,

--- a/shared/src/config_shared.rs
+++ b/shared/src/config_shared.rs
@@ -1,4 +1,5 @@
 use beam_lib::ProxyId;
+use reqwest::{Certificate, Url};
 use crate::{
     config::CONFIG_SHARED_CRYPTO,
     crypto::{
@@ -9,15 +10,12 @@ use crate::{
 };
 use axum::async_trait;
 use clap::Parser;
-use hyper::Uri;
-use hyper_tls::native_tls::Certificate;
 use jwt_simple::prelude::RS256KeyPair;
 use openssl::{
     asn1::Asn1IntegerRef,
     x509::{self, X509},
 };
 use rsa::{pkcs1::DecodeRsaPrivateKey, pkcs8::DecodePrivateKey, RsaPrivateKey};
-use static_init::dynamic;
 use std::{fs::read_to_string, path::PathBuf, rc::Rc, sync::Arc};
 use tracing::{debug, info};
 
@@ -46,7 +44,7 @@ struct CliArgs {
     // TODO: The following arguments have been added for compatibility reasons with the proxy config. Find another way to merge configs.
     /// (included for technical reasons)
     #[clap(long, env, value_parser)]
-    broker_url: Uri,
+    broker_url: Url,
 
     /// (included for technical reasons)
     #[clap(long, env, value_parser)]
@@ -66,7 +64,7 @@ pub struct Config {
     pub(crate) tls_ca_certificates_dir: Option<PathBuf>,
     pub broker_domain: String,
     pub root_cert: X509,
-    pub tls_ca_certificates: Vec<X509>,
+    pub tls_ca_certificates: Vec<Certificate>,
 }
 
 #[derive(Debug, Clone)]

--- a/shared/src/errors.rs
+++ b/shared/src/errors.rs
@@ -1,7 +1,7 @@
 use std::{net::AddrParseError, str::Utf8Error, string::FromUtf8Error};
 
-use http::StatusCode;
 use openssl::error::ErrorStack;
+use reqwest::StatusCode;
 use tokio::time::error::Elapsed;
 use beam_lib::ProxyId;
 
@@ -26,7 +26,7 @@ pub enum SamplyBeamError {
     #[error("Samply.PKI error: Vault is still sealed.")]
     VaultSealed,
     #[error("Samply.PKI error: Unable to connect to Vault: {0}")]
-    VaultUnreachable(hyper::Error),
+    VaultUnreachable(reqwest::Error),
     #[error("Samply.PKI error: Vault has not been initialized, yet.")]
     VaultNotInitialized,
     #[error("Samply.PKI error: Vault has asked with code {0} to redirect to {1}; this should not happen.")]
@@ -38,9 +38,9 @@ pub enum SamplyBeamError {
     #[error("Internal synchronization error: {0}")]
     InternalSynchronizationError(String),
     #[error("Error executing HTTP request: {0}")]
-    HttpRequestError(hyper::Error),
-    #[error("Error building HTTP request: {0}")]
-    HttpRequestBuildError(#[from] http::Error),
+    HttpRequestError(#[from] reqwest::Error),
+    // #[error("Error building HTTP request: {0}")]
+    // HttpRequestBuildError(#[from] http::Error),
     #[error("Problem with HTTP proxy: {0}")]
     HttpProxyProblem(std::io::Error),
     #[error("Invalid Beam ID: {0}")]
@@ -72,12 +72,6 @@ impl From<ErrorStack> for SamplyBeamError {
 impl From<rsa::errors::Error> for SamplyBeamError {
     fn from(e: rsa::errors::Error) -> Self {
         Self::SignEncryptError(e.to_string())
-    }
-}
-
-impl From<hyper::Error> for SamplyBeamError {
-    fn from(e: hyper::Error) -> Self {
-        Self::HttpRequestError(e)
     }
 }
 

--- a/shared/src/http_client.rs
+++ b/shared/src/http_client.rs
@@ -25,7 +25,8 @@ pub fn build(
         builder = builder.add_root_certificate(cert.clone());
     }
 
-    // This is not doing the logic that reqwest does ofc. reqwest supports all proxy env config vars in upper and lower case
+    // This is not doing the logic that reqwest does ofc. reqwest supports all proxy env config vars in upper and lower case.
+    // This is just for display purposes as reqwest does not expose which proxies it loaded.
     let proxies = std::env::vars()
         .filter(|(k, _)| k.to_ascii_lowercase().contains("proxy"))
         .collect::<Vec<_>>();

--- a/shared/src/http_client.rs
+++ b/shared/src/http_client.rs
@@ -1,59 +1,41 @@
 use std::{collections::HashSet, ops::Deref, time::Duration};
 
 use axum::async_trait;
-use http::{Request, Response, Uri};
-use hyper::{
-    client::{conn, connect::Connect, HttpConnector},
-    service::Service,
-    Body, Client,
-};
-use hyper_proxy::{Custom, Intercept, Proxy, ProxyConnector};
-use hyper_timeout::TimeoutConnector;
-use hyper_tls::{
-    native_tls::{Certificate, TlsConnector},
-    HttpsConnector,
-};
-use mz_http_proxy::hyper::connector;
+use axum::http::{Request, Response, Uri};
+use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use openssl::x509::X509;
+use reqwest::{Certificate, Client, ClientBuilder};
 use tracing::{debug, info, warn};
 
 use crate::{config, errors::SamplyBeamError};
 
-pub type SamplyHttpClient = Client<TimeoutConnector<ProxyConnector<HttpsConnector<HttpConnector>>>>;
+pub type SamplyHttpClient = reqwest::Client;
 
 pub fn build(
-    ca_certificates: &Vec<X509>,
+    ca_certificates: &Vec<Certificate>,
     timeout: Option<Duration>,
     keepalive: Option<Duration>,
-) -> Result<SamplyHttpClient, std::io::Error> {
-    let mut http = HttpConnector::new();
-    http.set_connect_timeout(Some(Duration::from_secs(1)));
-    http.enforce_http(false);
-    http.set_keepalive(keepalive);
-    let tls = build_tls_connector(ca_certificates)?;
-    let https = HttpsConnector::from((http, tls.clone().into()));
-    let proxy_connector = connector()
-        .map_err(|e| panic!("Unable to build HTTP client: {}", e))
-        .unwrap();
-    let mut proxy_connector = proxy_connector.with_connector(https);
-    proxy_connector.set_tls(Some(tls));
-
-    let proxies = proxy_connector
-        .proxies()
-        .iter()
-        .map(|p| p.uri().to_string())
-        .collect::<HashSet<_>>();
-
-    if proxies.len() == 0 && ca_certificates.len() > 0 {
-        warn!("Certificates for TLS termination were provided but no proxy to use. If you want to set a proxy see https://docs.rs/mz-http-proxy/0.1.0/mz_http_proxy/#proxy-selection");
+) -> Result<SamplyHttpClient, SamplyBeamError> {
+    let mut builder = Client::builder().tcp_keepalive(keepalive);
+    if let Some(to) = timeout {
+        builder = builder.connect_timeout(to);
+    }
+    for cert in ca_certificates {
+        builder = builder.add_root_certificate(cert.clone());
     }
 
-    let proxies = match proxies.len() {
-        0 => "no proxy".to_string(),
-        1 => format!("proxy {}", proxies.iter().next().unwrap()),
-        num => format!("{num} proxies {:?}", proxies),
-    };
+    // This is not doing the logic that reqwest does ofc. reqwest supports all proxy env config vars in upper and lower case
+    let proxies = std::env::vars()
+        .filter(|(k, _)| k.to_ascii_lowercase().contains("proxy"))
+        .collect::<Vec<_>>();
+
+    if proxies.len() == 0 && ca_certificates.len() > 0 {
+        warn!("Certificates for TLS termination were provided but no proxy to use. If you want to set a proxy see https://docs.rs/reqwest/#proxies");
+    }
+
+    let proxies = proxies.into_iter().map(|(k, v)| format!("{k}={v}")).join(", ");
+
     let certs = match ca_certificates.len() {
         0 => "no trusted certificate".to_string(),
         1 => "a trusted certificate".to_string(),
@@ -61,32 +43,7 @@ pub fn build(
     };
     info!("Using {proxies} and {certs} for TLS termination.");
 
-    let mut timeout_connector = hyper_timeout::TimeoutConnector::new(proxy_connector);
-    timeout_connector.set_connect_timeout(timeout);
-    timeout_connector.set_read_timeout(timeout);
-    timeout_connector.set_write_timeout(timeout);
-
-    let client = Client::builder().build(timeout_connector);
-
-    Ok(client)
-}
-
-fn build_tls_connector(ca_certificates: &Vec<X509>) -> Result<TlsConnector, std::io::Error> {
-    let mut tls = TlsConnector::builder();
-    for cert in ca_certificates {
-        const ERR: &str = "Internal Error: Unable to convert Certificate.";
-        let cert = Certificate::from_pem(&cert.to_pem().expect(ERR)).expect(ERR);
-        tls.add_root_certificate(cert);
-    }
-    tls.build().map_err(|e| {
-        std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!(
-                "Unable to build TLS Connector with custom CA certificates: {}",
-                e
-            ),
-        )
-    })
+    builder.build().map_err(|e| SamplyBeamError::ConfigurationFailed(e.to_string()))
 }
 
 #[cfg(test)]
@@ -94,51 +51,28 @@ mod test {
 
     use std::path::{Path, PathBuf};
 
-    use hyper::{
-        body,
-        client::{connect::Connect, HttpConnector},
-        Client, Request, Uri,
-    };
-    use hyper_proxy::ProxyConnector;
-    use hyper_tls::HttpsConnector;
-    use openssl::x509::X509;
+    use reqwest::{Request, Url};
 
-    use crate::http_client::{self, SamplyHttpClient};
+    use crate::{http_client::{self, SamplyHttpClient}};
 
     const HTTP: &str = "http://ip-api.com/json";
     const HTTPS: &str = "https://ifconfig.me/";
 
-    fn get_certs() -> Vec<X509> {
-        if let Ok(dir) = std::env::var("TLS_CA_CERTIFICATES_DIR") {
-            let dir = PathBuf::from(dir);
-            crate::crypto::load_certificates_from_dir(Some(dir)).unwrap()
-        } else {
-            Vec::new()
-        }
-    }
-
     #[tokio::test]
     async fn https() {
-        let client = http_client::build(&get_certs(), None, None).unwrap();
+        let client = http_client::build(&vec![], None, None).unwrap();
         run(HTTPS.parse().unwrap(), client).await;
     }
 
     #[tokio::test]
     async fn http() {
-        let client = http_client::build(&get_certs(), None, None).unwrap();
+        let client = http_client::build(&vec![], None, None).unwrap();
         run(HTTP.parse().unwrap(), client).await;
     }
 
-    async fn run(url: Uri, client: SamplyHttpClient) {
-        let req = Request::builder()
-            .uri(url)
-            .body(body::Body::empty())
-            .unwrap();
+    async fn run(url: Url, client: SamplyHttpClient) {
+        let resp = client.get(url).send().await.unwrap();
 
-        let mut resp = client.request(req).await.unwrap();
-
-        let resp_string = body::to_bytes(resp.body_mut()).await.unwrap();
-
-        println!("=> {}\n", std::str::from_utf8(&resp_string).unwrap());
+        println!("=> {}\n", resp.text().await.unwrap());
     }
 }

--- a/shared/src/serde_helpers.rs
+++ b/shared/src/serde_helpers.rs
@@ -1,8 +1,7 @@
 use std::ops::Deref;
 
-use axum::{response::{IntoResponse, Response}, headers::{ContentType, HeaderMapExt}};
+use axum::{http::{header, HeaderValue, StatusCode}, response::{IntoResponse, Response}};
 use bytes::BufMut;
-use http::StatusCode;
 use serde::{Serialize, Serializer, ser::SerializeSeq};
 
 
@@ -119,7 +118,7 @@ impl IntoResponse for DerefSerializer {
         } else {
             StatusCode::PARTIAL_CONTENT
         };
-        resp.headers_mut().typed_insert(ContentType::json());
+        resp.headers_mut().insert(header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
         resp
     }
 }

--- a/shared/src/traits.rs
+++ b/shared/src/traits.rs
@@ -1,11 +1,10 @@
 use axum::{
     async_trait,
     extract::{self, FromRequest, FromRequestParts, Path, Query},
-    http::StatusCode,
+    http::{request::Parts, StatusCode},
     BoxError, RequestPartsExt,
 };
-use fundu::{DurationParser};
-use http::request::Parts;
+use fundu::DurationParser;
 
 use crate::*;
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,16 +6,14 @@ publish = false
 license = "Apache-2.0"
 
 [dependencies]
-tokio = { version = "1.28.0", features = ["macros", "io-util"] }
+tokio = { version = "1", features = ["macros", "io-util"] }
 beam-lib = { workspace = true, features = ["http-util"] }
-once_cell = "1.17.1"
-serde_json = "1.0.96"
-http = "0.2.9"
-anyhow = "1.0.71"
-hyper = { version = "0.14.27", features = ["client", "http1", "tcp"] }
-rand = "0.8.5"
-serde = { version = "1.0.163", features = ["derive"] }
-reqwest = { version = "0.11.20", features = ["stream"], default-features = false }
+once_cell = "1"
+serde_json = "1"
+anyhow = "1"
+rand = "0.8"
+serde = { version = "1", features = ["derive"] }
+reqwest = { version = "0.12", features = ["stream"], default-features = false }
 futures = "0.3.28"
 async-sse = "5.1.0"
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,6 +1,4 @@
 
-use http::{Request, header, StatusCode};
-use hyper::{Client, Body};
 use once_cell::sync::Lazy;
 use beam_lib::{AddressingId, set_broker_id, AppOrProxyId, BeamClient};
 
@@ -42,10 +40,13 @@ pub static CLIENT2: Lazy<BeamClient> = Lazy::new(|| BeamClient::new(&APP2, APP_K
 
 #[tokio::test]
 async fn test_time_out() {
-    let res = Client::new().request(Request::get("http://localhost:8081/v1/tasks?wait_count=100&filter=todo&wait_time=5s")
+    use reqwest::{header, StatusCode};
+    let res = reqwest::Client::new()
+        .get("http://localhost:8081/v1/tasks?wait_count=100&filter=todo&wait_time=5s")
         .header(header::AUTHORIZATION, format!("ApiKey {} {APP_KEY}", APP1.clone()))
-        .body(Body::empty()).unwrap()
-    ).await.unwrap();
+        .send()
+        .await
+        .unwrap();
 
     assert_eq!(res.status(), StatusCode::PARTIAL_CONTENT);
 }

--- a/tests/src/test_sse.rs
+++ b/tests/src/test_sse.rs
@@ -4,7 +4,7 @@ use anyhow::{Result, bail, anyhow};
 use async_sse::Event;
 use beam_lib::TaskResult;
 use futures::{StreamExt, TryStreamExt};
-use http::{Method, header, HeaderValue};
+use reqwest::{header::{self, HeaderValue}, Method};
 
 use crate::{CLIENT1, task_test};
 


### PR DESCRIPTION
This also:
- migrates to reqwest as the http client
- gets rid of static_init which seemed to be outdated
- removes dependency on hyper directly apart from sockets which still needs it
- relaxes version requirements

Closes #196, #194, #183. #182 