### PR TITLE
Timeout improvements

### DIFF
--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -18,7 +18,7 @@ httpdate = "1.0"
 
 # Error handling
 anyhow = "1"
-backoff = { version = "0.4", features = ["tokio"] }
+tryhard = "0.5"
 
 # Subscriber is imported through shared
 tracing = "0.1"

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -1,16 +1,18 @@
 #![allow(unused_imports)]
 
+use std::future::Future;
 use std::time::Duration;
 
 use axum::http::{header, HeaderValue, StatusCode};
-use backoff::{future::retry_notify, ExponentialBackoff};
 use beam_lib::AppOrProxyId;
+use futures::future::Ready;
 use shared::{reqwest, EncryptedMessage, MsgEmpty, PlainMessage};
 use shared::crypto::CryptoPublicPortion;
 use shared::errors::SamplyBeamError;
 use shared::http_client::{self, SamplyHttpClient};
 use shared::{config, config_proxy::Config};
 use tracing::{debug, error, info, warn};
+use tryhard::{backoff_strategies::ExponentialBackoff, RetryFuture, RetryFutureConfig};
 
 use crate::serve_tasks::sign_request;
 
@@ -38,38 +40,18 @@ pub async fn main() -> anyhow::Result<()> {
         Some(Duration::from_secs(20)),
     )?;
 
-    if let Err(err) = retry_notify(
-        ExponentialBackoff::default(),
-        || async { Ok(get_broker_health(&config, &client).await?) },
-        |err, dur: Duration| {
-            warn!(
-                "Still trying to reach Broker: {}. Retrying in {}s",
-                err,
-                dur.as_secs()
-            );
-        },
-    )
-    .await
-    {
-        error!("Giving up reaching Broker: {}", err);
+    if let Err(err) = retry_notify(|| get_broker_health(&config, &client), |err, dur| {
+        warn!("Still trying to reach Broker: {err}. Retrying in {}s", dur.as_secs());
+    }).await {
+        error!("Giving up reaching Broker: {err}");
         std::process::exit(1);
     } else {
         info!("Connected to Broker: {}", &config.broker_uri);
     }
 
-    if let Err(err) = retry_notify(
-        ExponentialBackoff::default(),
-        || async { Ok(init_crypto(config.clone(), client.clone()).await?) },
-        |err, dur: Duration| {
-            warn!(
-                "Still trying to initialize certificate chain: {}. Retrying in {}s",
-                err,
-                dur.as_secs()
-            );
-        },
-    )
-    .await
-    {
+    if let Err(err) = retry_notify(|| init_crypto(config.clone(), client.clone()), |err, dur| {
+        warn!("Still trying to initialize certificate chain: {err}. Retrying in {}s", dur.as_secs());
+    }).await {
         error!("Giving up on initializing certificate chain: {}", err);
         std::process::exit(1);
     } else {
@@ -79,6 +61,20 @@ pub async fn main() -> anyhow::Result<()> {
 
     serve::serve(config, client).await?;
     Ok(())
+}
+
+fn retry_notify<F, T, Fut, E, Cb>(f: F, on_error: Cb) -> RetryFuture<F, Fut, ExponentialBackoff, Box<dyn Fn(u32, Option<Duration>, &E) -> Ready<()>>>
+where 
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    Cb: Fn(&E, Duration) + 'static,
+    
+{
+    tryhard::retry_fn(f)
+        .retries(100)
+        .exponential_backoff(Duration::from_secs(1))
+        .max_delay(Duration::from_secs(120))
+        .on_retry(Box::new(move |_, b, e| futures::future::ready(on_error(e, b.unwrap_or(Duration::MAX)))))
 }
 
 async fn init_crypto(config: Config, client: SamplyHttpClient) -> Result<(), SamplyBeamError> {
@@ -117,28 +113,11 @@ async fn get_broker_health(
     let uri = config.broker_uri
         .join("/v1/health")
         .expect("Uri to be constructed correctly");
-
-    let resp = retry_notify(
-        backoff::ExponentialBackoffBuilder::default()
-            .with_max_interval(Duration::from_secs(10))
-            .with_max_elapsed_time(Some(Duration::from_secs(30)))
-            .build(),
-        || async {
-            Ok(client
-                .get(uri.clone())
-                .header(header::USER_AGENT, HeaderValue::from_static(env!("SAMPLY_USER_AGENT")))
-                .send()
-                .await?)
-        },
-        |err, b: Duration| {
-            warn!(
-                "Unable to connect to Broker: {}. Retrying in {}s",
-                err,
-                b.as_secs()
-            );
-        },
-    )
-    .await?;
+    let resp = client
+        .get(uri.clone())
+        .header(header::USER_AGENT, HeaderValue::from_static(env!("SAMPLY_USER_AGENT")))
+        .send()
+        .await?;
 
     match resp.status() {
         StatusCode::OK => Ok(()),


### PR DESCRIPTION
- refactor: Migrate retry handeling form `backoff` to `tryhard`
- fix: retry 502 status without delay in control connection

At some sites the status code returned by the proxy on timeout is 504 instead of 502 leading us to wait a minute before trying to reconnect.
But because 502 might also indicate a permanent problem with the network we don't want to spam the proxy as fast as possible with requests which is why I introduced a counter which keeps track of how many times we hit such a status code and if its more than 10 times in the last minute we retry only every minute.