### PR TITLE
Sockets to streams

### DIFF
--- a/beam-lib/Cargo.toml
+++ b/beam-lib/Cargo.toml
@@ -9,10 +9,12 @@ license = "Apache-2.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
-reqwest = { version = "0.12", features = ["json"], default-features = false, optional = true }
+reqwest = { version = "0.12", features = ["json", "stream"], default-features = false, optional = true }
 thiserror = { version = "1.0", optional = true }
+futures-core = { version = "0.3", optional = true }
+bytes = { version = "1.7.1", optional = true }
 
 [features]
 strict-ids = []
 http-util = ["dep:reqwest", "dep:thiserror"]
-sockets = []
+sockets = ["dep:futures-core", "dep:bytes"]

--- a/broker/Cargo.toml
+++ b/broker/Cargo.toml
@@ -31,11 +31,10 @@ once_cell = "1"
 # Socket dependencies
 bytes = { version = "1", optional = true }
 axum-extra = { version = "0.9", features = ["typed-header"] }
-hyper = { version = "1", default-features = false, optional = true}
-hyper-util = { version = "0.1", default-features = false, features = ["tokio"], optional = true}
+futures-util = { version = "0.3", default-features = false, optional = true }
 
 [features]
-sockets = ["dep:bytes", "shared/sockets", "dep:hyper", "dep:hyper-util"]
+sockets = ["dep:bytes", "shared/sockets", "dep:futures-util"]
 
 [build-dependencies]
 build-data = "0"

--- a/broker/src/serve_sockets.rs
+++ b/broker/src/serve_sockets.rs
@@ -1,16 +1,14 @@
-use std::{borrow::Cow, collections::{HashMap, HashSet}, ops::Deref, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
-use axum::{body::{Body, BodyDataStream}, extract::{Path, Request, State}, http::{header, request::Parts, StatusCode}, response::{IntoResponse, Response}, routing::get, RequestExt, Router};
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use axum::{body::{Body, BodyDataStream}, extract::{Path, State}, http::{header, request::Parts, StatusCode}, response::{IntoResponse, Response}, routing::get, Router};
+use bytes::{BufMut, Bytes, BytesMut};
 use dashmap::mapref::entry::Entry;
-use futures_core::TryStream;
 use futures_util::{stream, StreamExt};
-use serde::{Serialize, Serializer, ser::SerializeSeq};
-use shared::{config::{CONFIG_CENTRAL, CONFIG_SHARED}, crypto_jwt::Authorized, errors::SamplyBeamError, expire_map::LazyExpireMap, serde_helpers::DerefSerializer, Encrypted, HasWaitId, HowLongToBlock, Msg, MsgEmpty, MsgId, MsgSigned, MsgSocketRequest};
-use tokio::{sync::{broadcast::{self, Sender}, oneshot, RwLock}, time::Instant};
-use tracing::{debug, log::error, warn, Span};
+use shared::{expire_map::LazyExpireMap, serde_helpers::DerefSerializer, Encrypted, HasWaitId, HowLongToBlock, Msg, MsgEmpty, MsgId, MsgSigned, MsgSocketRequest};
+use tokio::{sync::oneshot, time::Instant};
+use tracing::{debug, warn};
 
-use crate::task_manager::{TaskManager, Task};
+use crate::task_manager::TaskManager;
 
 
 #[derive(Clone)]

--- a/dev/beamdev
+++ b/dev/beamdev
@@ -259,6 +259,8 @@ check_prereqs
 if [ "$1" == "--tag" ]; then
     TAG="$2"
     shift 2
+else
+    TAG="localbuild"
 fi
 
 case "$1" in

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -31,7 +31,6 @@ serde_json = "1"
 rsa = "0.9"
 
 # Server-sent Events (SSE) support
-tokio-util = { version = "0.7", features = ["io"] }
 futures = "0.3"
 async-sse = "5.1"
 async-stream = "0.3"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -37,13 +37,11 @@ async-sse = "5.1"
 async-stream = "0.3"
 
 # Socket dependencies
-chacha20poly1305 = { version = "0.10", features = ["stream"], optional = true }
+crypto_secretstream = { version = "0.2", optional = true }
 dashmap =  { version = "6.0", optional = true}
-hyper = { version = "1", default-features = false, optional = true }
-hyper-util = { version = "0.1", default-features = false, features = ["tokio"], optional = true}
 
 [features]
-sockets = ["dep:chacha20poly1305", "dep:dashmap", "tokio-util/codec", "tokio-util/compat", "shared/sockets", "shared/expire_map", "dep:hyper", "dep:hyper-util"]
+sockets = ["dep:crypto_secretstream", "dep:dashmap", "shared/sockets", "shared/expire_map"]
 
 [build-dependencies]
 build-data = "0"

--- a/proxy/src/crypto.rs
+++ b/proxy/src/crypto.rs
@@ -36,7 +36,7 @@ impl GetCertsFromBroker {
         let req = sign_request(body, parts, &self.config, Some(&self.crypto_conf))
             .await
             .map_err(|(_, msg)| SamplyBeamError::SignEncryptError(msg.into()))?;
-        Ok(self.client.execute(req).await?.into())
+        Ok(self.client.execute(req.try_into().unwrap()).await?.into())
     }
 
     async fn query(&self, path: &str) -> Result<String, SamplyBeamError> {

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -146,7 +146,7 @@ fn spawn_controller_polling(client: SamplyHttpClient, config: Config) {
 
             let req = sign_request(body, parts, &config, None).await.expect("Unable to sign request; this should always work");
             // In the future this will poll actual control related tasks
-            match client.execute(req).await {
+            match client.execute(req.try_into().unwrap()).await {
                 Ok(res) => {
                     match res.status() {
                         StatusCode::OK => {

--- a/proxy/src/serve_sockets.rs
+++ b/proxy/src/serve_sockets.rs
@@ -155,6 +155,7 @@ async fn create_socket_con(
     };
     let (mut parts, body) = req.into_parts();
     parts.headers.append(header::TRANSFER_ENCODING, HeaderValue::from_static("chunked"));
+    parts.headers.append(header::CONNECTION, HeaderValue::from_static("keep-alive"));
     let stream = stream::once(ready(Ok(body))).chain(Encrypter::new(key).encrypt(og_req.into_body().into_data_stream()));
     let req = Request::from_parts(parts, reqwest::Body::wrap_stream(stream));
     match state.client.execute(req.try_into().expect("Conversion to reqwest::Request should always work")).await {

--- a/proxy/src/serve_sockets.rs
+++ b/proxy/src/serve_sockets.rs
@@ -1,5 +1,5 @@
 use std::{
-    future::ready, io::{self, Write}, ops::{Deref, DerefMut}, pin::Pin, sync::Arc, task::Poll, time::{Duration, Instant, SystemTime}
+    future::ready, sync::Arc, task::Poll, time::{Duration, SystemTime}
 };
 
 use axum::{
@@ -17,7 +17,6 @@ use shared::{
     config, ct_codecs::{self, Base64UrlSafeNoPadding, Decoder as B64Decoder, Encoder as B64Encoder}, expire_map::LazyExpireMap, http_client::SamplyHttpClient, reqwest, MessageType, MsgEmpty, MsgId, MsgSocketRequest, Plain
 };
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf, ReadHalf, WriteHalf};
-use tokio_util::codec::{Decoder, Encoder, Framed, FramedRead, FramedWrite};
 use tracing::{warn, debug};
 
 use crate::{

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -21,7 +21,7 @@ axum = { version = "0.7", features = [] }
 bytes = "1.4"
 
 # HTTP client with proxy support
-reqwest = { version = "0.12", features = ["stream", "json"] }
+reqwest = { version = "0.12", features = ["stream"] }
 
 # Logging
 tracing = "0.1"
@@ -55,7 +55,7 @@ beam-lib = { workspace = true }
 
 [features]
 expire_map = ["dep:dashmap"]
-sockets = ["expire_map", "beam-lib/sockets"]
+sockets = ["expire_map", "beam-lib/sockets", "reqwest/json"]
 default = []
 config-for-proxy = []
 config-for-central = []

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -21,7 +21,7 @@ axum = { version = "0.7", features = [] }
 bytes = "1.4"
 
 # HTTP client with proxy support
-reqwest = { version = "0.12", features = ["stream"] }
+reqwest = { version = "0.12", features = ["stream", "json"] }
 
 # Logging
 tracing = "0.1"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 license = "Apache-2.0"
 
-[dependencies]
+[dev-dependencies]
 tokio = { version = "1", features = ["macros", "io-util"] }
 beam-lib = { workspace = true, features = ["http-util"] }
 once_cell = "1"

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,14 +1,13 @@
+#![cfg(test)]
 
 use once_cell::sync::Lazy;
 use beam_lib::{AddressingId, set_broker_id, AppOrProxyId, BeamClient};
 
-#[cfg(all(feature = "sockets", test))]
+#[cfg(feature = "sockets")]
 mod socket_test;
 
-#[cfg(test)]
 mod task_test;
 
-#[cfg(test)]
 mod test_sse;
 
 pub static APP1: Lazy<AddressingId> = Lazy::new(|| {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -35,8 +35,12 @@ pub const APP_KEY: &str = match option_env!("APP_KEY") {
     None => "App1Secret"
 };
 
-pub static CLIENT1: Lazy<BeamClient> = Lazy::new(|| BeamClient::new(&APP1, APP_KEY, PROXY1.parse().unwrap()));
-pub static CLIENT2: Lazy<BeamClient> = Lazy::new(|| BeamClient::new(&APP2, APP_KEY, PROXY2.parse().unwrap()));
+pub fn client1() -> BeamClient {
+    BeamClient::new(&APP1, APP_KEY, PROXY1.parse().unwrap())
+}
+pub fn client2() -> BeamClient {
+    BeamClient::new(&APP2, APP_KEY, PROXY2.parse().unwrap())
+}
 
 #[tokio::test]
 async fn test_time_out() {

--- a/tests/src/test_sse.rs
+++ b/tests/src/test_sse.rs
@@ -6,12 +6,12 @@ use beam_lib::TaskResult;
 use futures::{StreamExt, TryStreamExt};
 use reqwest::{header::{self, HeaderValue}, Method};
 
-use crate::{CLIENT1, task_test};
+use crate::{client1, task_test};
 
 #[tokio::test]
 async fn test_sse() -> Result<()> {
     let id = task_test::post_task("test").await?;
-    let res = CLIENT1
+    let res = client1()
         .raw_beam_request(
             Method::GET,
             &format!("v1/tasks/{id}/results?wait_count=1"),


### PR DESCRIPTION
This changes beams socket protocol from the bidirectional sockets interface to a unidirectional streaming interface. This change was motivated by several practical issues with proxies that did not allow http request upgrades by default.
The new approach uses streaming http bodies which should be supported by all regular proxies.

Open questions:

- [ ] Should we rename the endpoints from `/v1/sockets` to `/v1/stream[s]`
- [x] ~There seems to be a regression with the tasks endpoint~