### PR TITLE
fix(sockets): return right headers for request upgrade

### DIFF
--- a/broker/src/serve_sockets.rs
+++ b/broker/src/serve_sockets.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, collections::{HashMap, HashSet}, ops::Deref, time::Duration};
 
-use axum::{extract::{Path, Request, State}, http::{header, request::Parts, StatusCode}, response::{IntoResponse, Response}, routing::get, RequestExt, Router};
+use axum::{extract::{Path, Request, State}, http::{header, request::Parts, HeaderValue, StatusCode}, response::{IntoResponse, Response}, routing::get, RequestExt, Router};
 use bytes::BufMut;
 use hyper_util::rt::TokioIo;
 use serde::{Serialize, Serializer, ser::SerializeSeq};
@@ -131,5 +131,8 @@ async fn connect_socket(
             }
         });
     }
-    Err(StatusCode::SWITCHING_PROTOCOLS)
+    Ok(([
+        (header::UPGRADE, HeaderValue::from_static("tcp")),
+        (header::CONNECTION, HeaderValue::from_static("upgrade"))
+    ], StatusCode::SWITCHING_PROTOCOLS).into_response())
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -35,8 +35,12 @@ pub const APP_KEY: &str = match option_env!("APP_KEY") {
     None => "App1Secret"
 };
 
-pub static CLIENT1: Lazy<BeamClient> = Lazy::new(|| BeamClient::new(&APP1, APP_KEY, PROXY1.parse().unwrap()));
-pub static CLIENT2: Lazy<BeamClient> = Lazy::new(|| BeamClient::new(&APP2, APP_KEY, PROXY2.parse().unwrap()));
+pub fn client1() -> BeamClient {
+    BeamClient::new(&APP1, APP_KEY, PROXY1.parse().unwrap())
+}
+pub fn client2() -> BeamClient {
+    BeamClient::new(&APP2, APP_KEY, PROXY2.parse().unwrap())
+}
 
 #[tokio::test]
 async fn test_time_out() {

--- a/tests/src/socket_test.rs
+++ b/tests/src/socket_test.rs
@@ -30,17 +30,17 @@ async fn test_full() -> Result<()> {
         "id": id
     });
     let app1 = async {
-        CLIENT1.create_socket_with_metadata(&APP2, &metadata).await.map_err(anyhow::Error::from)
+        client1().create_socket_with_metadata(&APP2, &metadata).await.map_err(anyhow::Error::from)
     };
     let app2 = async {
-        let task = CLIENT2
-            .get_socket_tasks(&BlockingOptions::from_time(Duration::from_secs(1)))
+        let task = client2()
+            .get_socket_tasks(&beam_lib::BlockingOptions::from_count(1))
             .await?
             .into_iter()
             .find(|t| t.metadata["id"].as_str() == Some(&id_str))
             .ok_or(anyhow::anyhow!("Failed to get a socket task"))?;
         assert_eq!(&task.metadata, &metadata);
-        Ok(CLIENT2.connect_socket(&task.id).await?)
+        Ok(client2().connect_socket(&task.id).await?)
     };
 
     let (app1, app2) = tokio::try_join!(app1, app2)?;

--- a/tests/src/socket_test.rs
+++ b/tests/src/socket_test.rs
@@ -1,33 +1,43 @@
+use std::time::Duration;
+
+use beam_lib::{BlockingOptions, MsgId};
 use rand::RngCore;
 use tokio::io::{AsyncWriteExt, AsyncReadExt, AsyncRead, AsyncWrite};
 use anyhow::Result;
 use crate::*;
 
 async fn test_connection<T: AsyncRead + AsyncWrite + Unpin>(mut a: T, mut b: T) -> Result<()> {
-    const N: usize = 2_usize.pow(13);
-    let test_data: &mut [u8; N] = &mut [0; N];
-    rand::thread_rng().fill_bytes(test_data);
-    let mut read_buf = [0; N];
-    a.write_all(test_data).await?;
-    a.flush().await?;
-    b.read_exact(&mut read_buf).await?;
-    assert_eq!(test_data, &read_buf);
+    const N: usize = 2_usize.pow(8);
+    for _ in 0..10 {
+        let test_data: &mut [u8; N] = &mut [0; N];
+        rand::thread_rng().fill_bytes(test_data);
+        let mut read_buf = [0; N];
+        a.write_all(test_data).await?;
+        a.flush().await?;
+        b.read_exact(&mut read_buf).await?;
+        assert_eq!(test_data, &read_buf);
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
     Ok(())
 }
 
 #[tokio::test]
 async fn test_full() -> Result<()> {
+    let id = MsgId::new();
+    let id_str = id.to_string();
     let metadata = serde_json::json!({
         "foo": vec![1, 2, 3],
+        "id": id
     });
     let app1 = async {
         CLIENT1.create_socket_with_metadata(&APP2, &metadata).await.map_err(anyhow::Error::from)
     };
     let app2 = async {
         let task = CLIENT2
-            .get_socket_tasks(&beam_lib::BlockingOptions::from_count(1))
+            .get_socket_tasks(&BlockingOptions::from_time(Duration::from_secs(1)))
             .await?
-            .pop()
+            .into_iter()
+            .find(|t| t.metadata["id"].as_str() == Some(&id_str))
             .ok_or(anyhow::anyhow!("Failed to get a socket task"))?;
         assert_eq!(&task.metadata, &metadata);
         Ok(CLIENT2.connect_socket(&task.id).await?)

--- a/tests/src/test_sse.rs
+++ b/tests/src/test_sse.rs
@@ -6,12 +6,12 @@ use beam_lib::TaskResult;
 use futures::{StreamExt, TryStreamExt};
 use reqwest::{header::{self, HeaderValue}, Method};
 
-use crate::{CLIENT1, task_test};
+use crate::{client1, task_test};
 
 #[tokio::test]
 async fn test_sse() -> Result<()> {
     let id = task_test::post_task("test").await?;
-    let res = CLIENT1
+    let res = client1()
         .raw_beam_request(
             Method::GET,
             &format!("v1/tasks/{id}/results?wait_count=1"),


### PR DESCRIPTION
Supersedes #210 

According to the spec we should return the protocol we decided on which I just called tcp and enforced the name everywhere because we don't want the client to decided as httpd for example only permits upgrades of names that it knows about:
```
<VirtualHost *:80>
    ProxyPass / http://broker:8080/ upgrade=tcp
    ProxyPassReverse / http://broker:8080/
</VirtualHost>
```
Also I improved the test a so that it works even if we run a lot of them in parallel