### PR TITLE
fix: don't crash on double connection

### DIFF
--- a/broker/src/serve_health.rs
+++ b/broker/src/serve_health.rs
@@ -7,6 +7,7 @@ use futures_core::Stream;
 use serde::{Serialize, Deserialize};
 use shared::{crypto_jwt::Authorized, Msg, config::CONFIG_CENTRAL};
 use tokio::sync::{Mutex, OwnedMutexGuard, RwLock};
+use tracing::info;
 
 use crate::compare_client_server_version::log_version_mismatch;
 
@@ -145,7 +146,8 @@ async fn get_control_tasks(
         .clone();
     let Ok(connect_guard) = tokio::time::timeout(Duration::from_secs(60), status_mutex.lock_owned()).await
     else {
-        return Err(StatusCode::CONFLICT);
+        info!("Double connection!");
+        return Err(StatusCode::OK);
     };
 
     Ok(Sse::new(ForeverStream(connect_guard)).keep_alive(KeepAlive::new()))


### PR DESCRIPTION
While this kind of defeats the purpose we kind of rely on this working for the secret-sync gitlab token checks in the background and also noticing disconnects **even with a 15s heartbeat from the server** seems to be inconsistent when some weird proxies are involved.
This leading to crashes of the beam proxies is not ideal. So lets log if we have a double connection instead.
This way we can tell if there is a legitimate double connection if the message occurs in a 1m interval for a site.
We should probably release this as a patch to main today.