### PR TITLE
fix: only crash when our own cert did not get resigned

### DIFF
--- a/proxy/src/crypto.rs
+++ b/proxy/src/crypto.rs
@@ -33,7 +33,7 @@ impl GetCertsFromBroker {
             .expect("To build request successfully")
             .into_parts();
 
-        let req = sign_request(body, parts, &self.config, Some(&self.crypto_conf))
+        let req = sign_request(body, parts, &self.config, &self.crypto_conf)
             .await
             .map_err(|(_, msg)| SamplyBeamError::SignEncryptError(msg.into()))?;
         Ok(self.client.execute(req).await?.into())
@@ -89,20 +89,6 @@ impl GetCerts for GetCertsFromBroker {
     async fn im_certificate_as_pem(&self) -> Result<String, SamplyBeamError> {
         debug!("Retrieving intermediate CA certificate ...");
         self.query("/v1/pki/certs/im-ca").await
-    }
-
-    async fn on_cert_expired(&self, expired_cert: shared::openssl::x509::X509) {
-        // We can't use our own `ConfigCrypto` here as it is only an intermidate config for getting initial certs from the broker
-        let own_cert = shared::crypto::get_own_crypto_material()
-            .public
-            .as_ref()
-            .expect("Fatal error: Unable to read our own certificate.");
-        let own_cert = &own_cert.cert;
-        if expired_cert.serial_number() == own_cert.serial_number() {
-            // TODO Tobias will find a smart solution ;)
-            error!("Our own cert has just expired -- exiting.");
-            std::process::exit(13);
-        }
     }
 }
 

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -8,7 +8,7 @@ use beam_lib::AppOrProxyId;
 use futures::future::Ready;
 use futures::{StreamExt, TryStreamExt};
 use shared::{reqwest, EncryptedMessage, MsgEmpty, PlainMessage};
-use shared::crypto::CryptoPublicPortion;
+use shared::crypto::{get_own_crypto_material, CryptoPublicPortion, ProxyCertInfo};
 use shared::errors::SamplyBeamError;
 use shared::http_client::{self, SamplyHttpClient};
 use shared::{config, config_proxy::Config};
@@ -96,13 +96,13 @@ async fn init_crypto(config: Config, client: SamplyHttpClient) -> Result<(), Sam
                     .ok()
             })
             .collect();
-    let (serial, cname) =
+    let ProxyCertInfo { serial, common_name, .. } =
         shared::config_shared::init_public_crypto_for_proxy(private_crypto_proxy).await?;
-    if cname != config.proxy_id.to_string() {
-        return Err(SamplyBeamError::ConfigurationFailed(format!("Unable to retrieve a certificate matching your Proxy ID. Expected {}, got {}. Please check your configuration", cname, config.proxy_id.to_string())));
+    if common_name != config.proxy_id.to_string() {
+        return Err(SamplyBeamError::ConfigurationFailed(format!("Unable to retrieve a certificate matching your Proxy ID. Expected {common_name}, got {}. Please check your configuration", config.proxy_id.as_ref())));
     }
 
-    info!("Certificate retrieved for our proxy ID {cname} (serial {serial})");
+    info!("Certificate retrieved for our proxy ID {common_name} (serial {serial})");
 
     Ok(())
 }
@@ -148,7 +148,7 @@ fn spawn_controller_polling(client: SamplyHttpClient, config: Config) {
                 .expect("To build request successfully")
                 .into_parts();
 
-            let req = sign_request(body, parts, &config, None).await.expect("Unable to sign request; this should always work");
+            let req = sign_request(body, parts, &config, &get_own_crypto_material()).await.expect("Unable to sign request; this should always work");
             // In the future this will poll actual control related tasks
             let res = match client.execute(req).await {
                 Ok(res) if res.status() == StatusCode::CONFLICT => {

--- a/proxy/src/serve_tasks.rs
+++ b/proxy/src/serve_tasks.rs
@@ -17,7 +17,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 use beam_lib::{AppId, AppOrProxyId, ProxyId};
 use shared::{
-    config::{self, CONFIG_PROXY}, config_proxy, config_shared::ConfigCrypto, crypto::{self, CryptoPublicPortion}, crypto_jwt, errors::SamplyBeamError, http_client::SamplyHttpClient, reqwest, sse_event::SseEventType, DecryptableMsg, EncryptableMsg, EncryptedMessage, EncryptedMsgTaskRequest, EncryptedMsgTaskResult, MessageType, Msg, MsgEmpty, MsgId, MsgSigned, MsgTaskRequest, MsgTaskResult, PlainMessage
+    config::{self, CONFIG_PROXY}, config_proxy, config_shared::ConfigCrypto, crypto::{self, get_own_crypto_material, CryptoPublicPortion}, crypto_jwt, errors::SamplyBeamError, http_client::SamplyHttpClient, reqwest, sse_event::SseEventType, DecryptableMsg, EncryptableMsg, EncryptedMessage, EncryptedMsgTaskRequest, EncryptedMsgTaskResult, MessageType, Msg, MsgEmpty, MsgId, MsgSigned, MsgTaskRequest, MsgTaskResult, PlainMessage
 };
 use tokio::io::BufReader;
 use tracing::{debug, error, info, trace, warn};
@@ -83,7 +83,7 @@ pub(crate) async fn forward_request(
         HeaderValue::from_static(env!("SAMPLY_USER_AGENT")),
     );
     let (encrypted_msg, parts) = encrypt_request(req, &sender).await?;
-    let req = sign_request(encrypted_msg, parts, &config, None).await.map_err(IntoResponse::into_response)?;
+    let req = sign_request(encrypted_msg, parts, &config, &get_own_crypto_material()).await.map_err(IntoResponse::into_response)?;
     trace!("Requesting: {:?}", req);
     let resp = client.execute(req).await.map_err(|e| {
         if e.is_timeout() {
@@ -94,6 +94,10 @@ pub(crate) async fn forward_request(
             (StatusCode::BAD_GATEWAY, "Upstream error; see server logs.")
         }.into_response()
     })?;
+    if resp.status() == StatusCode::UNAUTHORIZED {
+        error!("The Broker has rejected our request with 401 Unauthorized. This is likely because our beam certificate expired.");
+        std::process::exit(401);
+    }
     Ok(resp)
 }
 
@@ -319,11 +323,11 @@ pub async fn sign_request(
     body: EncryptedMessage,
     mut parts: Parts,
     config: &config_proxy::Config,
-    private_crypto: Option<&ConfigCrypto>,
+    private_key: &ConfigCrypto,
 ) -> Result<reqwest::Request, (StatusCode, &'static str)> {
     let from = body.get_from();
 
-    let token_without_extended_signature = crypto_jwt::sign_to_jwt(&body, private_crypto)
+    let token_without_extended_signature = crypto_jwt::sign_to_jwt(&body, &private_key.privkey_rs256)
         .await
         .map_err(|e| {
             error!("Crypto failed: {}", e);
@@ -347,7 +351,7 @@ pub async fn sign_request(
     let digest =
         crypto_jwt::make_extra_fields_digest(&parts.method, &parts.uri, &headers_mut, sig, &from)
             .map_err(|_| ERR_INTERNALCRYPTO)?;
-    let token_with_extended_signature = crypto_jwt::sign_to_jwt(&digest, private_crypto)
+    let token_with_extended_signature = crypto_jwt::sign_to_jwt(&digest, &private_key.privkey_rs256)
         .await
         .map_err(|e| {
             error!("Crypto failed: {}", e);

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -56,7 +56,7 @@ async-trait = "0.1"
 
 [features]
 expire_map = ["dep:dashmap"]
-sockets = ["expire_map", "beam-lib/sockets"]
+sockets = ["expire_map", "beam-lib/sockets", "reqwest/json"]
 default = []
 config-for-proxy = []
 config-for-central = []

--- a/shared/src/config_shared.rs
+++ b/shared/src/config_shared.rs
@@ -4,7 +4,7 @@ use crate::{
     config::CONFIG_SHARED_CRYPTO,
     crypto::{
         self, get_all_certs_and_clients_by_cname_as_pemstr, load_certificates_from_dir,
-        CryptoPublicPortion, GetCerts,
+        CryptoPublicPortion, GetCerts, ProxyCertInfo,
     },
     SamplyBeamError,
 };
@@ -70,7 +70,6 @@ pub struct Config {
 pub struct ConfigCrypto {
     pub privkey_rs256: RS256KeyPair,
     pub privkey_rsa: RsaPrivateKey,
-    pub public: Option<CryptoPublicPortion>,
 }
 
 impl crate::config::Config for Config {
@@ -115,22 +114,16 @@ fn get_enrollment_msg(proxy_id: &Option<String>) -> String {
 }
 
 pub async fn init_public_crypto_for_proxy(
-    private_config: ConfigCrypto,
-) -> Result<(String, String), SamplyBeamError> {
+    mut config: ConfigCrypto,
+) -> Result<ProxyCertInfo, SamplyBeamError> {
     let cli_args = CliArgs::parse();
-    let crypto = load_public_crypto_for_proxy(&cli_args, private_config).await?;
+    let public_info = load_public_crypto_for_proxy(&cli_args, &mut config).await?;
 
-    let cert_info = crypto::ProxyCertInfo::try_from(
-        &crypto
-            .public
-            .as_ref()
-            .expect("Should be set by load_public_crypto_for_proxy")
-            .cert,
-    )?;
-    if CONFIG_SHARED_CRYPTO.set(crypto).is_err() {
+    let cert_info = crypto::ProxyCertInfo::try_from(&public_info.cert)?;
+    if CONFIG_SHARED_CRYPTO.set(config).is_err() {
         panic!("Tried to initialize crypto twice (init_public_crypto_for_proxy())");
     }
-    Ok((cert_info.serial, cert_info.common_name))
+    Ok(cert_info)
 }
 
 pub fn load_private_crypto_for_proxy() -> Result<ConfigCrypto, SamplyBeamError> {
@@ -163,14 +156,13 @@ pub fn load_private_crypto_for_proxy() -> Result<ConfigCrypto, SamplyBeamError> 
     Ok(ConfigCrypto {
         privkey_rs256,
         privkey_rsa,
-        public: None,
     })
 }
 
 async fn load_public_crypto_for_proxy(
     cli_args: &CliArgs,
-    mut config: ConfigCrypto,
-) -> Result<ConfigCrypto, SamplyBeamError> {
+    config: &mut ConfigCrypto,
+) -> Result<CryptoPublicPortion, SamplyBeamError> {
     let proxy_id = cli_args.proxy_id.as_ref()
         .expect("load_crypto() has been called without setting a Proxy ID (maybe in broker?). This should not happen.");
     let proxy_id = ProxyId::new(proxy_id)?;
@@ -188,9 +180,8 @@ async fn load_public_crypto_for_proxy(
         ),
     )?;
     let serial = asn_str_to_vault_str(public.cert.serial_number())?;
-    config.privkey_rs256 = config.privkey_rs256.with_key_id(&serial);
-    config.public = Some(public);
-    Ok(config)
+    config.privkey_rs256 = config.privkey_rs256.clone().with_key_id(&serial);
+    Ok(public)
 }
 
 fn asn_str_to_vault_str(asn: &Asn1IntegerRef) -> Result<String, SamplyBeamError> {

--- a/shared/src/crypto.rs
+++ b/shared/src/crypto.rs
@@ -37,12 +37,12 @@ use crate::{
 
 type Serial = String;
 
-pub(crate) struct ProxyCertInfo {
-    pub(crate) proxy_name: String,
-    pub(crate) valid_since: String,
-    pub(crate) valid_until: String,
-    pub(crate) common_name: String,
-    pub(crate) serial: String,
+pub struct ProxyCertInfo {
+    pub proxy_name: String,
+    pub valid_since: String,
+    pub valid_until: String,
+    pub common_name: String,
+    pub serial: String,
 }
 
 impl TryFrom<&X509> for ProxyCertInfo {
@@ -119,7 +119,6 @@ pub trait GetCerts: Sync + Send {
     async fn im_certificate_as_pem(&self) -> Result<String, SamplyBeamError>;
     /// A callback that runs on a timer and returns if the cache changed
     async fn on_timer(&self, _cache: &mut CertificateCache) -> CertificateCacheUpdate { CertificateCacheUpdate::UnChanged }
-    async fn on_cert_expired(&self, _expired_cert: X509) {}
     async fn get_crl(&self) -> Result<Option<X509Crl>, SamplyBeamError> { Ok(None) }
 }
 
@@ -197,7 +196,6 @@ impl CertificateCache {
             };
             *entry = CertificateCacheEntry::Invalid(CertificateInvalidReason::InvalidDate);
         }
-        CERT_GETTER.get().unwrap().on_cert_expired(oldest_cert).await;
     }
 
     /// Searches cache for a certificate with the given ClientId. If not found, updates cache from central vault. If then still not found, return None
@@ -569,10 +567,6 @@ pub(crate) static CERT_CACHE: Lazy<Arc<RwLock<CertificateCache>>> = Lazy::new(||
     });
     cc
 });
-
-async fn get_cert_by_serial(serial: &str) -> Option<X509> {
-    CertificateCache::get_by_serial(serial).await
-}
 
 async fn get_all_certs_by_cname(cname: &ProxyId) -> Vec<CertificateCacheEntry> {
     CertificateCache::get_all_certs_by_cname(cname).await

--- a/shared/src/crypto_jwt.rs
+++ b/shared/src/crypto_jwt.rs
@@ -229,19 +229,10 @@ pub async fn verify_with_extended_header<M: Msg + DeserializeOwned>(
 
 pub async fn sign_to_jwt(
     input: impl Serialize,
-    crypto_conf: Option<&ConfigCrypto>,
+    privkey: &RS256KeyPair,
 ) -> Result<String, SamplyBeamError> {
     let json = serde_json::to_value(input)
         .map_err(|e| SamplyBeamError::SignEncryptError(format!("Serialization failed: {}", e)))?;
-    let privkey = if let Some(ConfigCrypto { privkey_rs256, .. }) = crypto_conf {
-        privkey_rs256
-    } else {
-        &config::CONFIG_SHARED_CRYPTO
-            .get()
-            .expect("If called by GetCertsFromBroker config needs to be provided by param")
-            .privkey_rs256
-    };
-
     let claims = Claims::with_custom_claims::<Value>(json, Duration::from_hours(1)); // TODO: Make variable
 
     let token = privkey


### PR DESCRIPTION
I think just crashing on a 409 from the broker is way easier than trying to keep track of our own public key and checking if the cert that just expired was ours.
With the old system we would have needed to put the crypto public portion in a mutex/rwlock in order to update it when the first certificate we got on startup expired.
Also this gets rid of the awkward two step init of `ConfigCrypto`.