### PR TITLE
Rootless mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Samply.Beam (upcoming release)
+
+## Major changes
+
+* Rootless mode: Upon startup, Beam will try to drop their privileges to the non-root `nobody` user. If this fails, Beam will issue a warning and continue with its current user. Use the new `--require-nonroot` flag to enforce non-root mode.
+
 # Samply.Beam 0.10.0 - 2025-05-26
 
 ## Breaking changes

--- a/broker/src/main.rs
+++ b/broker/src/main.rs
@@ -16,7 +16,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use crypto::GetCertsFromPki;
 use serve_health::{Health, InitStatus};
 use once_cell::sync::Lazy;
-use shared::{config::CONFIG_CENTRAL, *, errors::SamplyBeamError};
+use shared::{config::CONFIG_CENTRAL, drop_privileges::drop_privileges_or_fail, errors::SamplyBeamError, *};
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
@@ -36,6 +36,8 @@ pub async fn main() -> anyhow::Result<()> {
     }
 
     Lazy::force(&config::CONFIG_CENTRAL); // Initialize config
+
+    drop_privileges_or_fail();
 
     serve::serve(health).await?;
 

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -11,7 +11,7 @@ use shared::{reqwest, EncryptedMessage, MsgEmpty, PlainMessage};
 use shared::crypto::{get_own_crypto_material, CryptoPublicPortion, ProxyCertInfo};
 use shared::errors::SamplyBeamError;
 use shared::http_client::{self, SamplyHttpClient};
-use shared::{config, config_proxy::Config};
+use shared::{config, config_proxy::Config, drop_privileges::drop_privileges_or_fail};
 use tokio::time::Instant;
 use tracing::{debug, error, info, warn};
 use tryhard::{backoff_strategies::ExponentialBackoff, RetryFuture, RetryFutureConfig};
@@ -58,6 +58,9 @@ pub async fn main() -> anyhow::Result<()> {
     } else {
         debug!("Certificate chain successfully initialized and validated");
     }
+
+    drop_privileges_or_fail();
+
     spawn_controller_polling(client.clone(), config.clone());
 
     serve::serve(config, client).await?;

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -54,6 +54,8 @@ dashmap =  { version = "6.0", optional = true}
 beam-lib = { workspace = true }
 async-trait = "0.1"
 
+privdrop = "0.5.6"
+
 [features]
 expire_map = ["dep:dashmap"]
 sockets = ["expire_map", "beam-lib/sockets", "reqwest/json"]

--- a/shared/src/config_broker.rs
+++ b/shared/src/config_broker.rs
@@ -53,6 +53,10 @@ struct CliArgs {
     #[clap(long, env, value_parser)]
     monitoring_api_key: Option<String>,
 
+    /// Abort if we fail to drop our root privileges (defaults to false)
+    #[clap(long, env, value_parser, default_value = "false")]
+    require_nonroot: bool,
+
     /// (included for technical reasons)
     #[clap(long, hide(true))]
     test_threads: Option<String>,

--- a/shared/src/config_proxy.rs
+++ b/shared/src/config_proxy.rs
@@ -63,6 +63,10 @@ pub struct CliArgs {
     #[clap(long, env, value_parser, default_value = "/run/secrets/root.crt.pem")]
     rootcert_file: PathBuf,
 
+    /// Abort if we fail to drop our root privileges (defaults to false)
+    #[clap(long, env, value_parser, default_value = "false")]
+    require_nonroot: bool,
+
     /// (included for technical reasons)
     #[clap(long, hide(true))]
     test_threads: Option<String>,

--- a/shared/src/config_shared.rs
+++ b/shared/src/config_shared.rs
@@ -40,6 +40,10 @@ struct CliArgs {
     #[clap(long, env, value_parser, default_value = "/run/secrets/root.crt.pem")]
     rootcert_file: PathBuf,
 
+    /// Abort if we fail to drop our root privileges (defaults to false)
+    #[clap(long, env, value_parser, default_value = "false")]
+    require_nonroot: bool,
+
     // TODO: The following arguments have been added for compatibility reasons with the proxy config. Find another way to merge configs.
     /// (included for technical reasons)
     #[clap(long, env, value_parser)]
@@ -64,6 +68,7 @@ pub struct Config {
     pub broker_domain: String,
     pub root_cert: X509,
     pub tls_ca_certificates: Vec<Certificate>,
+    pub require_nonroot: bool
 }
 
 #[derive(Debug, Clone)]
@@ -98,6 +103,7 @@ impl crate::config::Config for Config {
             tls_ca_certificates_dir,
             root_cert,
             tls_ca_certificates,
+            require_nonroot: cli_args.require_nonroot,
         })
     }
 }

--- a/shared/src/drop_privileges.rs
+++ b/shared/src/drop_privileges.rs
@@ -1,0 +1,18 @@
+use privdrop::PrivDrop;
+use tracing::{error, warn};
+
+use crate::config;
+
+pub fn drop_privileges_or_fail() {
+    if let Err(err) = PrivDrop::default()
+        .user("nobody")
+        .group("nobody")
+        .apply() {
+            if config::CONFIG_SHARED.require_nonroot {
+                error!("Failed to drop privileges: {err}");
+                std::process::exit(1);
+            } else {
+                warn!("Failed to drop privileges: {err}; continuing as root.")
+            }
+        }
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -41,6 +41,7 @@ pub type TaskResponse = String;
 
 pub mod crypto;
 pub mod crypto_jwt;
+pub mod drop_privileges;
 pub mod errors;
 pub mod serde_helpers;
 pub mod logger;


### PR DESCRIPTION
Upon startup, Beam will try to drop their privileges to the non-root `nobody` user. If this fails, Beam will issue a warning and continue with its current user. Use the new `--require-nonroot` flag to enforce non-root mode.

This should be feature complete but is as of now untested.