### PR TITLE
chore: replace async-sse with sse-stream

### DIFF
--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -33,9 +33,9 @@ serde_json = "1"
 rsa = "0.9"
 
 # Server-sent Events (SSE) support
-tokio-util = { version = "0.7", features = ["io"] }
+tokio-util = "0.7"
 futures.workspace = true
-async-sse = "5.1"
+sse-stream = "0.2.3"
 async-stream = "0.3"
 
 # Socket dependencies

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -7,18 +7,19 @@ use axum::http::{header, HeaderValue, StatusCode};
 use beam_lib::AppOrProxyId;
 use clap::Parser;
 use futures::future::Ready;
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use shared::{reqwest, EncryptedMessage, MsgEmpty, PlainMessage};
 use shared::crypto::{CryptoPublicPortion, ProxyCertInfo};
 use shared::errors::SamplyBeamError;
 use shared::http_client::{self, SamplyHttpClient};
+use sse_stream::SseStream;
 use tokio::time::Instant;
 use tracing::{debug, error, info, warn};
 use tryhard::{backoff_strategies::ExponentialBackoff, RetryFuture, RetryFutureConfig};
 
 use crate::config::{CliArgs, Config};
 use crate::crypto::GetCertsFromBroker;
-use crate::serve_tasks::sign_request;
+use crate::serve_tasks::{sign_request, sse_error_is_timeout};
 
 mod auth;
 mod banner;
@@ -198,18 +199,11 @@ fn spawn_controller_polling(client: SamplyHttpClient, config: &'static Config) {
                     continue;
                 }
             };
-            let incoming = res
-                .bytes_stream()
-                .map(|result| result.map_err(|error| {
-                    let kind = error.is_timeout().then_some(std::io::ErrorKind::TimedOut).unwrap_or(std::io::ErrorKind::Other);
-                    std::io::Error::new(kind, format!("IO Error: {error}"))
-                }))
-                .into_async_read();
-            let mut reader = async_sse::decode(incoming);
+            let mut reader = SseStream::from_byte_stream(res.bytes_stream());
             while let Some(ev) = reader.next().await {
                 match ev {
                     Ok(_)=> (),
-                    Err(e) if e.downcast_ref::<std::io::Error>().unwrap().kind() == std::io::ErrorKind::TimedOut => {
+                    Err(e) if sse_error_is_timeout(&e) => {
                         debug!("SSE connection timed out");
                         break;
                     },

--- a/proxy/src/serve_tasks.rs
+++ b/proxy/src/serve_tasks.rs
@@ -8,7 +8,7 @@ use axum::{
     body::Bytes, extract::{FromRef, Request, State}, http::{header, request::Parts, HeaderMap, HeaderValue, StatusCode, Uri}, response::{sse::Event, IntoResponse, Response, Sse}, routing::{any, get, put}, Json, RequestExt, Router
 };
 use futures::{
-    stream::{StreamExt, TryStreamExt},
+    stream::StreamExt,
     Stream, TryFutureExt,
 };
 use httpdate::fmt_http_date;
@@ -19,6 +19,7 @@ use beam_lib::{AppId, AppOrProxyId, ProxyId};
 use shared::{
     DecryptableMsg, EncryptableMsg, EncryptedMessage, EncryptedMsgTaskRequest, EncryptedMsgTaskResult, MessageType, Msg, MsgEmpty, MsgId, MsgSigned, MsgTaskRequest, MsgTaskResult, PlainMessage, crypto::{self, CryptoPublicPortion}, crypto_jwt, errors::SamplyBeamError, format_to_without_broker, http_client::SamplyHttpClient, reqwest, sse_event::SseEventType
 };
+use sse_stream::SseStream;
 use tokio::{io::BufReader, task::id};
 use tracing::{debug, error, info, trace, warn};
 
@@ -199,20 +200,12 @@ async fn handler_tasks_stream(
     }
 
     let outgoing = async_stream::stream! {
-        let incoming = resp
-            .bytes_stream()
-            .map(|result| result.map_err(|error| {
-                let kind = error.is_timeout().then_some(std::io::ErrorKind::TimedOut).unwrap_or(std::io::ErrorKind::Other);
-                std::io::Error::new(kind, format!("IO Error: {error}"))
-            }))
-            .into_async_read();
-
-        let mut reader = async_sse::decode(incoming);
+        let mut reader = SseStream::from_byte_stream(resp.bytes_stream());
 
         while let Some(event) = reader.next().await {
             let event = match event {
-                Ok(event)=> event,
-                Err(e) if e.downcast_ref::<std::io::Error>().unwrap().kind() == std::io::ErrorKind::TimedOut => {
+                Ok(event) => event,
+                Err(e) if sse_error_is_timeout(&e) => {
                     debug!("SSE connection timed out");
                     break;
                 },
@@ -224,86 +217,92 @@ async fn handler_tasks_stream(
                     continue;
                 }
             };
-            match event {
-                async_sse::Event::Retry(_dur) => {
-                    error!("Got a retry message from the Broker, which is not yet supported.");
-                },
-                async_sse::Event::Message(event) => {
-                    // Check if this is a message or some control event
-                    let event_type = SseEventType::from_str(event.name()).expect("Error in Infallible");
-                    let mut event_as_bytes = event.into_bytes();
-                    let event_as_str = std::str::from_utf8(&event_as_bytes).unwrap_or("(unable to parse)");
+            if event.retry.is_some() && event.event.is_none() && event.data.is_none() {
+                error!("Got a retry message from the Broker, which is not yet supported.");
+                continue;
+            }
+            // Check if this is a message or some control event
+            let event_type = SseEventType::from_str(event.event.as_deref().unwrap_or("")).expect("Error in Infallible");
+            let mut event_as_bytes = event.data.unwrap_or_default().into_bytes();
+            let event_as_str = std::str::from_utf8(&event_as_bytes).unwrap_or("(unable to parse)");
 
-                    match &event_type {
-                        SseEventType::DeletedTask | SseEventType::WaitExpired => {
-                            debug!("SSE: Got {event_type} message, forwarding to App.");
-                            yield Ok(Event::default()
-                                .event(event_type)
-                                .data(event_as_str));
-                            continue;
-                        },
-                        SseEventType::Error => {
-                            warn!("SSE: The Broker has reported an error: {event_as_str}");
-                            yield Ok(Event::default()
-                                .event(event_type)
-                                .data(event_as_str));
-                            continue;
-                        },
-                        SseEventType::Undefined => {
-                            error!("SSE: Got a message without event type -- discarding.");
-                            continue;
-                        },
-                        SseEventType::Unknown(s) => {
-                            error!("SSE: Got unknown event type: {s} -- discarding.");
-                            continue;
-                        },
-                        SseEventType::NewResult => {
-                            debug!("SSE: Got new result");
-                        }
-                        other => {
-                            info!("Got \"{other}\" event -- parsing.");
-                        }
-                    }
-
-                    // Check reply's signature
-
-                    if !event_as_bytes.is_empty() {
-                        let Ok(json) = serde_json::from_slice::<Value>(&event_as_bytes) else {
-                            warn!("Answer is no valid JSON; discarding: \"{event_as_str}\".");
-                            // TODO: For some reason, compiler won't accept the following lines, so we can't inform the App about the problem.
-                            //
-                            // warn!("Answer is no valid JSON; returning as-is to client: \"{event_as_str}\".");
-                            // yield Ok(Event::default()
-                            //     .event(SseEventType::Error)
-                            //     .data(format!("Broker sent invalid JSON: {event_as_str}")));
-                            continue;
-                        };
-                        let json = match validate_and_decrypt(json, config).await {
-                            Ok(json) => json,
-                            Err(err) => {
-                                warn!("Got an error decrypting Broker's reply: {err}");
-                                continue;
-                            }
-                        };
-                        trace!("Decrypted Msg: {:#?}",json);
-                        event_as_bytes = serde_json::to_vec(&json).unwrap();
-                        trace!(
-                            "Validated and stripped signature: \"{}\"",
-                            std::str::from_utf8(&event_as_bytes).unwrap_or("Unable to parse string as UTF-8")
-                        );
-                    }
-                    let as_string = std::str::from_utf8(&event_as_bytes).unwrap_or("(garbled_utf8)");
-                    let event = Event::default()
+            match &event_type {
+                SseEventType::DeletedTask | SseEventType::WaitExpired => {
+                    debug!("SSE: Got {event_type} message, forwarding to App.");
+                    yield Ok(Event::default()
                         .event(event_type)
-                        .data(as_string);
-                    yield Ok(event);
+                        .data(event_as_str));
+                    continue;
+                },
+                SseEventType::Error => {
+                    warn!("SSE: The Broker has reported an error: {event_as_str}");
+                    yield Ok(Event::default()
+                        .event(event_type)
+                        .data(event_as_str));
+                    continue;
+                },
+                SseEventType::Undefined => {
+                    error!("SSE: Got a message without event type -- discarding.");
+                    continue;
+                },
+                SseEventType::Unknown(s) => {
+                    error!("SSE: Got unknown event type: {s} -- discarding.");
+                    continue;
+                },
+                SseEventType::NewResult => {
+                    debug!("SSE: Got new result");
+                }
+                other => {
+                    info!("Got \"{other}\" event -- parsing.");
                 }
             }
+
+            // Check reply's signature
+
+            if !event_as_bytes.is_empty() {
+                let Ok(json) = serde_json::from_slice::<Value>(&event_as_bytes) else {
+                    warn!("Answer is no valid JSON; discarding: \"{event_as_str}\".");
+                    // TODO: For some reason, compiler won't accept the following lines, so we can't inform the App about the problem.
+                    //
+                    // warn!("Answer is no valid JSON; returning as-is to client: \"{event_as_str}\".");
+                    // yield Ok(Event::default()
+                    //     .event(SseEventType::Error)
+                    //     .data(format!("Broker sent invalid JSON: {event_as_str}")));
+                    continue;
+                };
+                let json = match validate_and_decrypt(json, config).await {
+                    Ok(json) => json,
+                    Err(err) => {
+                        warn!("Got an error decrypting Broker's reply: {err}");
+                        continue;
+                    }
+                };
+                trace!("Decrypted Msg: {:#?}",json);
+                event_as_bytes = serde_json::to_vec(&json).unwrap();
+                trace!(
+                    "Validated and stripped signature: \"{}\"",
+                    std::str::from_utf8(&event_as_bytes).unwrap_or("Unable to parse string as UTF-8")
+                );
+            }
+            let as_string = std::str::from_utf8(&event_as_bytes).unwrap_or("(garbled_utf8)");
+            let event = Event::default()
+                .event(event_type)
+                .data(as_string);
+            yield Ok(event);
         }
     };
     // TODO: Somehow return correct error code (not always possible since headers are sent before long request)
     let sse = Sse::new(outgoing);
     Ok(sse)
+}
+
+pub(crate) fn sse_error_is_timeout(err: &sse_stream::Error) -> bool {
+    match err {
+        sse_stream::Error::Body(err) => err
+            .downcast_ref::<reqwest::Error>()
+            .is_some_and(reqwest::Error::is_timeout),
+        _ => false,
+    }
 }
 
 pub(crate) fn to_server_error<T>(res: Result<T, SamplyBeamError>) -> Result<T, Response> {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,7 +15,7 @@ rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 reqwest = { workspace = true, features = ["stream"], default-features = false }
 futures.workspace = true
-async-sse = "5.1.0"
+sse-stream = "0.2.3"
 
 [features]
 sockets = ["beam-lib/sockets"]

--- a/tests/src/test_sse.rs
+++ b/tests/src/test_sse.rs
@@ -1,10 +1,8 @@
-use std::io;
-
 use anyhow::{Result, bail, anyhow};
-use async_sse::Event;
 use beam_lib::TaskResult;
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use reqwest::{header::{self, HeaderValue}, Method};
+use sse_stream::SseStream;
 
 use crate::{client1, task_test};
 
@@ -25,10 +23,7 @@ async fn test_sse() -> Result<()> {
     task_test::put_result(id, "foo", Some(beam_lib::WorkStatus::Claimed)).await?;
     task_test::put_result(id, "foo", Some(beam_lib::WorkStatus::Claimed)).await?;
     task_test::put_result(id, "bar", Some(beam_lib::WorkStatus::Succeeded)).await?;
-    let mut stream = async_sse::decode(res.bytes_stream()
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
-        .into_async_read()
-    );
+    let mut stream = SseStream::from_byte_stream(res.bytes_stream());
     assert_body(stream.next().await, "foo")?;
     assert_body(stream.next().await, "foo")?;
     assert_body(stream.next().await, "bar")?;
@@ -36,14 +31,13 @@ async fn test_sse() -> Result<()> {
     Ok(())
 }
 
-fn assert_body<E>(event: Option<Result<Event, E>>, expected_body: &str) -> Result<()> {
+fn assert_body<E>(event: Option<Result<sse_stream::Sse, E>>, expected_body: &str) -> Result<()> {
     let Ok(event) = event.ok_or(anyhow!("SSE stream ended early"))? else {
         bail!("Unexpected error parsing SSE")
     };
-    let Event::Message(m) = event else {
-        bail!("Event is not a message");
-    };
-    let result = serde_json::from_slice::<TaskResult<String>>(m.data())?;
+    let result = serde_json::from_str::<TaskResult<String>>(
+        event.data.as_deref().ok_or(anyhow!("Event has no data"))?,
+    )?;
     assert_eq!(result.body, expected_body);
     Ok(())
 }


### PR DESCRIPTION
The old library was very outdated and had some dependency that got flagged by cargo audit.